### PR TITLE
Fix up issues with Cypress driver on OS X.

### DIFF
--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACF45CF91A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp */; };
 		F158186C1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */; settings = {ASSET_TAGS = (); }; };
 		F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */; settings = {ASSET_TAGS = (); }; };
+		F1AB82D01C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */; settings = {ASSET_TAGS = (); }; };
+		F1AB82D11C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +28,8 @@
 		ACF45CF91A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CHIDDevice.cpp; sourceTree = "<group>"; };
 		F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCyapaGen3Device.cpp; sourceTree = "<group>"; };
 		F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCyapaGen3Device.h; sourceTree = "<group>"; };
+		F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooHIDMouseWrapper.cpp; sourceTree = "<group>"; };
+		F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooHIDMouseWrapper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +71,8 @@
 				F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */,
 				308C59891BC61FE00078D1B1 /* VoodooHIDWrapper.h */,
 				308C59871BC61FD20078D1B1 /* VoodooHIDWrapper.cpp */,
+				F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */,
+				F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */,
 			);
 			path = VoodooI2C;
 			sourceTree = "<group>";
@@ -86,6 +92,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1AB82D11C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h in Headers */,
 				F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */,
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
 			);
@@ -158,6 +165,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1AB82D01C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp in Sources */,
 				308C59881BC61FD20078D1B1 /* VoodooHIDWrapper.cpp in Sources */,
 				ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */,
 				AC45AFEF1A32543B008E6857 /* VoodooI2C.cpp in Sources */,

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -30,7 +30,7 @@
 			<string>VoodooI2C</string>
 			<key>IONameMatch</key>
 			<array>
-				<string>INT33C2</string>
+				<string>INT33C3</string>
 			</array>
 			<key>IOProviderClass</key>
 			<string>IOACPIPlatformDevice</string>

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -30,7 +30,7 @@
 			<string>VoodooI2C</string>
 			<key>IONameMatch</key>
 			<array>
-				<string>INT33C3</string>
+				<string>INT33C2</string>
 			</array>
 			<key>IOProviderClass</key>
 			<string>IOACPIPlatformDevice</string>

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -39,6 +39,129 @@ typedef unsigned char BYTE;
 
 #define KBD_KEY_CODES        6
 
+unsigned char cyapadesc[] = {
+    //
+    // Relative mouse report starts here
+    //
+    0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
+    0x09, 0x02,                         // USAGE (Mouse)
+    0xa1, 0x01,                         // COLLECTION (Application)
+    0x85, REPORTID_RELATIVE_MOUSE,      //   REPORT_ID (Mouse)
+    0x09, 0x01,                         //   USAGE (Pointer)
+    0xa1, 0x00,                         //   COLLECTION (Physical)
+    0x05, 0x09,                         //     USAGE_PAGE (Button)
+    0x19, 0x01,                         //     USAGE_MINIMUM (Button 1)
+    0x29, 0x05,                         //     USAGE_MAXIMUM (Button 5)
+    0x15, 0x00,                         //     LOGICAL_MINIMUM (0)
+    0x25, 0x01,                         //     LOGICAL_MAXIMUM (1)
+    0x75, 0x01,                         //     REPORT_SIZE (1)
+    0x95, 0x05,                         //     REPORT_COUNT (5)
+    0x81, 0x02,                         //     INPUT (Data,Var,Abs)
+    0x95, 0x03,                         //     REPORT_COUNT (3)
+    0x81, 0x03,                         //     INPUT (Cnst,Var,Abs)
+    0x05, 0x01,                         //     USAGE_PAGE (Generic Desktop)
+    0x09, 0x30,                         //     USAGE (X)
+    0x09, 0x31,                         //     USAGE (Y)
+    0x15, 0x81,                         //     Logical Minimum (-127)
+    0x25, 0x7F,                         //     Logical Maximum (127)
+    0x75, 0x08,                         //     REPORT_SIZE (8)
+    0x95, 0x02,                         //     REPORT_COUNT (2)
+    0x81, 0x06,                         //     INPUT (Data,Var,Rel)
+    0x05, 0x01,                         //     Usage Page (Generic Desktop)
+    0x09, 0x38,                         //     Usage (Wheel)
+    0x15, 0x81,                         //     Logical Minimum (-127)
+    0x25, 0x7F,                         //     Logical Maximum (127)
+    0x75, 0x08,                         //     Report Size (8)
+    0x95, 0x01,                         //     Report Count (1)
+    0x81, 0x06,                         //     Input (Data, Variable, Relative)
+    // ------------------------------  Horizontal wheel
+    0x05, 0x0c,                         //     USAGE_PAGE (Consumer Devices)
+    0x0a, 0x38, 0x02,                   //     USAGE (AC Pan)
+    0x15, 0x81,                         //     LOGICAL_MINIMUM (-127)
+    0x25, 0x7f,                         //     LOGICAL_MAXIMUM (127)
+    0x75, 0x08,                         //     REPORT_SIZE (8)
+    0x95, 0x01,                         //     Report Count (1)
+    0x81, 0x06,                         //     Input (Data, Variable, Relative)
+    0xc0,                               //   END_COLLECTION
+    0xc0                               // END_COLLECTION
+    
+    /*//TOUCH PAD input TLC
+     0x05, 0x0d,                         // USAGE_PAGE (Digitizers)
+     0x09, 0x05,                         // USAGE (Touch Pad)
+     0xa1, 0x01,                         // COLLECTION (Application)
+     0x85, REPORTID_TOUCHPAD,            //   REPORT_ID (Touch pad)
+     0x09, 0x22,                         //   USAGE (Finger)
+     0xa1, 0x02,                         //   COLLECTION (Logical)
+     0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
+     0x25, 0x01,                         //       LOGICAL_MAXIMUM (1)
+     0x09, 0x47,                         //       USAGE (Confidence)
+     0x09, 0x42,                         //       USAGE (Tip switch)
+     0x95, 0x02,                         //       REPORT_COUNT (2)
+     0x75, 0x01,                         //       REPORT_SIZE (1)
+     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
+     0x95, 0x01,                         //       REPORT_COUNT (1)
+     0x75, 0x02,                         //       REPORT_SIZE (2)
+     0x25, 0x02,                         //       LOGICAL_MAXIMUM (2)
+     0x09, 0x51,                         //       USAGE (Contact Identifier)
+     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
+     0x75, 0x01,                         //       REPORT_SIZE (1)
+     0x95, 0x04,                         //       REPORT_COUNT (4)
+     0x81, 0x03,                         //       INPUT (Cnst,Var,Abs)
+     0x05, 0x01,                         //       USAGE_PAGE (Generic Desk..
+     0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
+     0x26, 0xff, 0x0f,                   //       LOGICAL_MAXIMUM (4095)
+     0x75, 0x10,                         //       REPORT_SIZE (16)
+     0x55, 0x0e,                         //       UNIT_EXPONENT (-2)
+     0x65, 0x13,                         //       UNIT(Inch,EngLinear)
+     0x09, 0x30,                         //       USAGE (X)
+     0x35, 0x00,                         //       PHYSICAL_MINIMUM (0)
+     0x46, 0x90, 0x01,                   //       PHYSICAL_MAXIMUM (400)
+     0x95, 0x01,                         //       REPORT_COUNT (1)
+     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
+     0x46, 0x13, 0x01,                   //       PHYSICAL_MAXIMUM (275)
+     0x09, 0x31,                         //       USAGE (Y)
+     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
+     0xc0,                               //    END_COLLECTION
+     0xc0,                               // END_COLLECTION*/
+    
+    //
+    // Keyboard report starts here
+    //
+    /*0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
+     0x09, 0x06,                         // USAGE (Keyboard)
+     0xa1, 0x01,                         // COLLECTION (Application)
+     0x85, REPORTID_KEYBOARD,            //   REPORT_ID (Keyboard)
+     0x05, 0x07,                         //   USAGE_PAGE (Keyboard)
+     0x19, 0xe0,                         //   USAGE_MINIMUM (Keyboard LeftControl)
+     0x29, 0xe7,                         //   USAGE_MAXIMUM (Keyboard Right GUI)
+     0x15, 0x00,                         //   LOGICAL_MINIMUM (0)
+     0x25, 0x01,                         //   LOGICAL_MAXIMUM (1)
+     0x75, 0x01,                         //   REPORT_SIZE (1)
+     0x95, 0x08,                         //   REPORT_COUNT (8)
+     0x81, 0x02,                         //   INPUT (Data,Var,Abs)
+     0x95, 0x01,                         //   REPORT_COUNT (1)
+     0x75, 0x08,                         //   REPORT_SIZE (8)
+     0x81, 0x03,                         //   INPUT (Cnst,Var,Abs)
+     0x95, 0x05,                         //   REPORT_COUNT (5)
+     0x75, 0x01,                         //   REPORT_SIZE (1)
+     0x05, 0x08,                         //   USAGE_PAGE (LEDs)
+     0x19, 0x01,                         //   USAGE_MINIMUM (Num Lock)
+     0x29, 0x05,                         //   USAGE_MAXIMUM (Kana)
+     0x91, 0x02,                         //   OUTPUT (Data,Var,Abs)
+     0x95, 0x01,                         //   REPORT_COUNT (1)
+     0x75, 0x03,                         //   REPORT_SIZE (3)
+     0x91, 0x03,                         //   OUTPUT (Cnst,Var,Abs)
+     0x95, 0x06,                         //   REPORT_COUNT (6)
+     0x75, 0x08,                         //   REPORT_SIZE (8)
+     0x15, 0x00,                         //   LOGICAL_MINIMUM (0)
+     0x25, 0x65,                         //   LOGICAL_MAXIMUM (101)
+     0x05, 0x07,                         //   USAGE_PAGE (Keyboard)
+     0x19, 0x00,                         //   USAGE_MINIMUM (Reserved (no event indicated))
+     0x29, 0x65,                         //   USAGE_MAXIMUM (Keyboard Application)
+     0x81, 0x00,                         //   INPUT (Data,Ary,Abs)
+     0xc0,                               // END_COLLECTION*/
+};
+
 typedef struct  __attribute__((__packed__)) _CYAPA_RELATIVE_MOUSE_REPORT
 {
     
@@ -402,11 +525,9 @@ void VoodooI2CCyapaGen3Device::ProcessGesture(csgesture_softc *sc) {
 void VoodooI2CCyapaGen3Device::TrackpadRawInput(struct csgesture_softc *sc, cyapa_regs *regs, int tickinc){
     int nfingers;
     
-    if ((regs->stat & CYAPA_STAT_RUNNING) == 0) {
-        regs->fngr = 0;
-    }
-    
     nfingers = CYAPA_FNGR_NUMFINGERS(regs->fngr);
+    
+    IOLog("Cyapa Fingers: %d\n", nfingers);
     
     for (int i = 0;i < 15;i++) {
         sc->x[i] = -1;
@@ -515,16 +636,30 @@ int VoodooI2CCyapaGen3Device::initHIDDevice(I2CDevice *hid_device) {
     int ret;
     UInt16 hidRegister;
     
+    uint8_t clear[] = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    
+    writeI2C(0x00, sizeof(clear), clear);
+    
     uint8_t bl_exit[] = {
-        0x00, 0xff, 0xa5, 0x00, 0x01,
+        0x00, 0x00, 0xff, 0xa5, 0x00, 0x01,
         0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+    
+    IOLog("%s", "Cyapa Hello!\n");
     
     cyapa_boot_regs boot;
     
     readI2C(0x00, sizeof(boot), (uint8_t *)&boot);
-    if ((boot.stat & CYAPA_STAT_RUNNING) == 0)
-        writeI2C(0x00, sizeof(bl_exit), bl_exit);
     
+    IOLog("Cypress Boot 0x%x 0x%x\n",boot.stat, boot.boot);
+    
+    if ((boot.stat & CYAPA_STAT_RUNNING) == 0){
+        ret = writeI2C(0x00, sizeof(bl_exit), bl_exit);
+        IOLog("%s %d", "Cyapa Boot Sent!\n",ret);
+    }
+    
+    IOLog("%s", "Cyapa Boot Done!\n");
     
     hid_device->workLoop = (IOWorkLoop*)getWorkLoop();
     if(!hid_device->workLoop) {
@@ -549,6 +684,7 @@ int VoodooI2CCyapaGen3Device::initHIDDevice(I2CDevice *hid_device) {
     
     hid_device->timerSource = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &VoodooI2CCyapaGen3Device::get_input));
     if (!hid_device->timerSource){
+        IOLog("%s", "Timer Err!\n");
         goto err;
     }
     
@@ -598,12 +734,51 @@ void VoodooI2CCyapaGen3Device::destroy_wrapper(void) {
     }
 }
 
+#define EIO              5      /* I/O error */
+#define ENOMEM          12      /* Out of memory */
+
 SInt32 VoodooI2CCyapaGen3Device::readI2C(uint8_t reg, size_t len, uint8_t *values){
-    return _controller->i2c_smbus_read_i2c_block_data(_controller->_dev, 0x67, reg, len, values);
+    struct VoodooI2C::i2c_msg msgs[] = {
+        {
+            .addr = 0x67,
+            .flags = 0,
+            .len = 1,
+            .buf = &reg,
+        },
+        {
+            .addr = 0x67,
+            .flags = I2C_M_RD,
+            .len = (uint8_t)len,
+            .buf = values,
+        },
+    };
+    int ret;
+    ret = _controller->i2c_transfer((VoodooI2C::i2c_msg*)msgs, ARRAY_SIZE(msgs));
+    if (ret != ARRAY_SIZE(msgs))
+        return ret < 0 ? ret : EIO;
+    return 0;
 }
 
 SInt32 VoodooI2CCyapaGen3Device::writeI2C(uint8_t reg, size_t len, uint8_t *values){
-    return _controller->i2c_smbus_write_i2c_block_data(_controller->_dev, 0x67, reg, len, values);
+    struct VoodooI2C::i2c_msg msgs[] = {
+        {
+            .addr = 0x67,
+            .flags = 0,
+            .len = 1,
+            .buf = &reg,
+        },
+        {
+            .addr = 0x67,
+            .flags = 0,
+            .len = (uint8_t)len,
+            .buf = values,
+        },
+    };
+    int ret;
+    
+    ret = _controller->i2c_transfer((VoodooI2C::i2c_msg*)&msgs, ARRAY_SIZE(msgs));
+    
+    return ret;
 }
 
 int VoodooI2CCyapaGen3Device::i2c_get_slave_address(I2CDevice* hid_device){
@@ -631,12 +806,16 @@ void VoodooI2CCyapaGen3Device::InterruptOccured(OSObject* owner, IOInterruptEven
 void VoodooI2CCyapaGen3Device::get_input(OSObject* owner, IOTimerEventSource* sender) {
     cyapa_regs regs;
     readI2C(0, sizeof(regs), (uint8_t *)&regs);
+    
+    IOLog("Regs: 0x%x 0x%x\n",regs.stat,regs.fngr);
+    
     TrackpadRawInput(&softc, &regs, 1);
+    IOLog("%s", "Cyapa Input Retrieved!\n");
     hid_device->timerSource->setTimeoutMS(10);
 }
 
-void VoodooI2CCyapaGen3Device::update_relative_mouse(uint8_t button,
-                                                     uint8_t x, uint8_t y, uint8_t wheelPosition, uint8_t wheelHPosition){
+void VoodooI2CCyapaGen3Device::update_relative_mouse(char button,
+                                                     char x, char y, char wheelPosition, char wheelHPosition){
     _CYAPA_RELATIVE_MOUSE_REPORT report;
     report.ReportID = REPORTID_RELATIVE_MOUSE;
     report.Button = button;
@@ -645,8 +824,12 @@ void VoodooI2CCyapaGen3Device::update_relative_mouse(uint8_t button,
     report.WheelPosition = wheelPosition;
     report.HWheelPosition = wheelHPosition;
     
+    IOLog("Relative Mouse Sent: %d %d %d %d %d\n",button,x,y,wheelPosition,wheelHPosition);
+    
     IOBufferMemoryDescriptor *buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(report));
     buffer->writeBytes(0, &report, sizeof(report));
+    
+    IOLog("Wrote Bytes: %lu\n",sizeof(report));
     
     IOReturn err = _wrapper->handleReport(buffer, kIOHIDReportTypeInput);
     if (err != kIOReturnSuccess)
@@ -655,131 +838,19 @@ void VoodooI2CCyapaGen3Device::update_relative_mouse(uint8_t button,
     buffer->release();
 }
 
+int VoodooI2CCyapaGen3Device::reportDescriptorLength(){
+    return sizeof(cyapadesc);
+}
+
+int VoodooI2CCyapaGen3Device::vendorID(){
+    return 'pyaC';
+}
+
+int VoodooI2CCyapaGen3Device::productID(){
+    return 'rtyC';
+}
+
 void VoodooI2CCyapaGen3Device::write_report_descriptor_to_buffer(IOBufferMemoryDescriptor *buffer){
-    
-    unsigned char cyapadesc[] = {
-        //
-        // Relative mouse report starts here
-        //
-        0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
-        0x09, 0x02,                         // USAGE (Mouse)
-        0xa1, 0x01,                         // COLLECTION (Application)
-        0x85, REPORTID_RELATIVE_MOUSE,      //   REPORT_ID (Mouse)
-        0x09, 0x01,                         //   USAGE (Pointer)
-        0xa1, 0x00,                         //   COLLECTION (Physical)
-        0x05, 0x09,                         //     USAGE_PAGE (Button)
-        0x19, 0x01,                         //     USAGE_MINIMUM (Button 1)
-        0x29, 0x05,                         //     USAGE_MAXIMUM (Button 5)
-        0x15, 0x00,                         //     LOGICAL_MINIMUM (0)
-        0x25, 0x01,                         //     LOGICAL_MAXIMUM (1)
-        0x75, 0x01,                         //     REPORT_SIZE (1)
-        0x95, 0x05,                         //     REPORT_COUNT (5)
-        0x81, 0x02,                         //     INPUT (Data,Var,Abs)
-        0x95, 0x03,                         //     REPORT_COUNT (3)
-        0x81, 0x03,                         //     INPUT (Cnst,Var,Abs)
-        0x05, 0x01,                         //     USAGE_PAGE (Generic Desktop)
-        0x09, 0x30,                         //     USAGE (X)
-        0x09, 0x31,                         //     USAGE (Y)
-        0x15, 0x81,                         //     Logical Minimum (-127)
-        0x25, 0x7F,                         //     Logical Maximum (127)
-        0x75, 0x08,                         //     REPORT_SIZE (8)
-        0x95, 0x02,                         //     REPORT_COUNT (2)
-        0x81, 0x06,                         //     INPUT (Data,Var,Rel)
-        0x05, 0x01,                         //     Usage Page (Generic Desktop)
-        0x09, 0x38,                         //     Usage (Wheel)
-        0x15, 0x81,                         //     Logical Minimum (-127)
-        0x25, 0x7F,                         //     Logical Maximum (127)
-        0x75, 0x08,                         //     Report Size (8)
-        0x95, 0x01,                         //     Report Count (1)
-        0x81, 0x06,                         //     Input (Data, Variable, Relative)
-        // ------------------------------  Horizontal wheel
-        0x05, 0x0c,                         //     USAGE_PAGE (Consumer Devices)
-        0x0a, 0x38, 0x02,                   //     USAGE (AC Pan)
-        0x15, 0x81,                         //     LOGICAL_MINIMUM (-127)
-        0x25, 0x7f,                         //     LOGICAL_MAXIMUM (127)
-        0x75, 0x08,                         //     REPORT_SIZE (8)
-        0x95, 0x01,                         //     Report Count (1)
-        0x81, 0x06,                         //     Input (Data, Variable, Relative)
-        0xc0,                               //   END_COLLECTION
-        0xc0,                               // END_COLLECTION
-        
-        /*//TOUCH PAD input TLC
-         0x05, 0x0d,                         // USAGE_PAGE (Digitizers)
-         0x09, 0x05,                         // USAGE (Touch Pad)
-         0xa1, 0x01,                         // COLLECTION (Application)
-         0x85, REPORTID_TOUCHPAD,            //   REPORT_ID (Touch pad)
-         0x09, 0x22,                         //   USAGE (Finger)
-         0xa1, 0x02,                         //   COLLECTION (Logical)
-         0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
-         0x25, 0x01,                         //       LOGICAL_MAXIMUM (1)
-         0x09, 0x47,                         //       USAGE (Confidence)
-         0x09, 0x42,                         //       USAGE (Tip switch)
-         0x95, 0x02,                         //       REPORT_COUNT (2)
-         0x75, 0x01,                         //       REPORT_SIZE (1)
-         0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-         0x95, 0x01,                         //       REPORT_COUNT (1)
-         0x75, 0x02,                         //       REPORT_SIZE (2)
-         0x25, 0x02,                         //       LOGICAL_MAXIMUM (2)
-         0x09, 0x51,                         //       USAGE (Contact Identifier)
-         0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-         0x75, 0x01,                         //       REPORT_SIZE (1)
-         0x95, 0x04,                         //       REPORT_COUNT (4)
-         0x81, 0x03,                         //       INPUT (Cnst,Var,Abs)
-         0x05, 0x01,                         //       USAGE_PAGE (Generic Desk..
-         0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
-         0x26, 0xff, 0x0f,                   //       LOGICAL_MAXIMUM (4095)
-         0x75, 0x10,                         //       REPORT_SIZE (16)
-         0x55, 0x0e,                         //       UNIT_EXPONENT (-2)
-         0x65, 0x13,                         //       UNIT(Inch,EngLinear)
-         0x09, 0x30,                         //       USAGE (X)
-         0x35, 0x00,                         //       PHYSICAL_MINIMUM (0)
-         0x46, 0x90, 0x01,                   //       PHYSICAL_MAXIMUM (400)
-         0x95, 0x01,                         //       REPORT_COUNT (1)
-         0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-         0x46, 0x13, 0x01,                   //       PHYSICAL_MAXIMUM (275)
-         0x09, 0x31,                         //       USAGE (Y)
-         0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-         0xc0,                               //    END_COLLECTION
-         0xc0,                               // END_COLLECTION*/
-        
-        //
-        // Keyboard report starts here
-        //
-        /*0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
-        0x09, 0x06,                         // USAGE (Keyboard)
-        0xa1, 0x01,                         // COLLECTION (Application)
-        0x85, REPORTID_KEYBOARD,            //   REPORT_ID (Keyboard)
-        0x05, 0x07,                         //   USAGE_PAGE (Keyboard)
-        0x19, 0xe0,                         //   USAGE_MINIMUM (Keyboard LeftControl)
-        0x29, 0xe7,                         //   USAGE_MAXIMUM (Keyboard Right GUI)
-        0x15, 0x00,                         //   LOGICAL_MINIMUM (0)
-        0x25, 0x01,                         //   LOGICAL_MAXIMUM (1)
-        0x75, 0x01,                         //   REPORT_SIZE (1)
-        0x95, 0x08,                         //   REPORT_COUNT (8)
-        0x81, 0x02,                         //   INPUT (Data,Var,Abs)
-        0x95, 0x01,                         //   REPORT_COUNT (1)
-        0x75, 0x08,                         //   REPORT_SIZE (8)
-        0x81, 0x03,                         //   INPUT (Cnst,Var,Abs)
-        0x95, 0x05,                         //   REPORT_COUNT (5)
-        0x75, 0x01,                         //   REPORT_SIZE (1)
-        0x05, 0x08,                         //   USAGE_PAGE (LEDs)
-        0x19, 0x01,                         //   USAGE_MINIMUM (Num Lock)
-        0x29, 0x05,                         //   USAGE_MAXIMUM (Kana)
-        0x91, 0x02,                         //   OUTPUT (Data,Var,Abs)
-        0x95, 0x01,                         //   REPORT_COUNT (1)
-        0x75, 0x03,                         //   REPORT_SIZE (3)
-        0x91, 0x03,                         //   OUTPUT (Cnst,Var,Abs)
-        0x95, 0x06,                         //   REPORT_COUNT (6)
-        0x75, 0x08,                         //   REPORT_SIZE (8)
-        0x15, 0x00,                         //   LOGICAL_MINIMUM (0)
-        0x25, 0x65,                         //   LOGICAL_MAXIMUM (101)
-        0x05, 0x07,                         //   USAGE_PAGE (Keyboard)
-        0x19, 0x00,                         //   USAGE_MINIMUM (Reserved (no event indicated))
-        0x29, 0x65,                         //   USAGE_MAXIMUM (Keyboard Application)
-        0x81, 0x00,                         //   INPUT (Data,Ary,Abs)
-        0xc0,                               // END_COLLECTION*/
-    };
-    
     
     UInt rsize = sizeof(cyapadesc);
     

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -226,16 +226,16 @@ void VoodooI2CCyapaGen3Device::ProcessScroll(csgesture_softc *sc, int abovethres
         if (abs(sc->scrolly) > 75)
             sc->scrolly = 0;
         if (sc->scrolly > 5)
-            sc->scrolly = 1;
-        else if (sc->scrolly < -5)
             sc->scrolly = -1;
+        else if (sc->scrolly < -5)
+            sc->scrolly = 1;
         else
             sc->scrolly = 0;
         
         if (sc->scrollx > 5)
-            sc->scrollx = -1;
-        else if (sc->scrollx < -5)
             sc->scrollx = 1;
+        else if (sc->scrollx < -5)
+            sc->scrollx = -1;
         else
             sc->scrollx = 0;
     }

--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -181,6 +181,23 @@ public:
         
     } I2CDevice;
     
+    struct i2c_msg {
+        UInt16 addr;
+        UInt16 flags;
+        UInt16 len;
+        UInt8 *buf;
+        
+#define I2C_M_TEN 0x0010
+#define I2C_M_RD 0x0001
+#define I2C_M_RECV_LEN 0x0400
+        
+#define I2C_HID_READ_PENDING (1 << 2);
+        
+#define I2C_HID_CMD(opcode_) \
+.opcode = opcode_, .length = 4,\
+.registerIndex = offsetof(struct i2c_hid_desc, wCommandRegister)
+    };
+    
     I2CDevice* hid_device;
     
     struct csgesture_softc softc;
@@ -193,6 +210,11 @@ public:
     
     void get_input(OSObject* owner, IOTimerEventSource* sender);
     
+    int reportDescriptorLength();
+    
+    int vendorID();
+    int productID();
+    
     void write_report_descriptor_to_buffer(IOBufferMemoryDescriptor *buffer);
     
     int i2c_get_slave_address(I2CDevice* hid_device);
@@ -200,8 +222,8 @@ public:
     SInt32 readI2C(uint8_t reg, size_t len, uint8_t *values);
     SInt32 writeI2C(uint8_t reg, size_t len, uint8_t *values);
     
-    void update_relative_mouse(uint8_t button,
-                          uint8_t x, uint8_t y, uint8_t wheelPosition, uint8_t wheelHPosition);
+    void update_relative_mouse(char button,
+                               char x, char y, char wheelPosition, char wheelHPosition);
     
     int distancesq(int delta_x, int delta_y);
     void ProcessMove(csgesture_softc *sc, int abovethreshold, int iToUse[3]);

--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -137,7 +137,7 @@ typedef struct __attribute__((__packed__)){
 } cyapa_regs;
 
 class VoodooI2C;
-class VoodooHIDWrapper;
+class VoodooHIDMouseWrapper;
 class IOBufferMemoryDescriptor;
 
 class VoodooI2CCyapaGen3Device : public IOService
@@ -146,7 +146,7 @@ class VoodooI2CCyapaGen3Device : public IOService
     OSDeclareDefaultStructors(VoodooI2CCyapaGen3Device);
     
 private:
-    VoodooHIDWrapper* _wrapper;
+    VoodooHIDMouseWrapper* _wrapper;
     
     void initialize_wrapper(void);
     void destroy_wrapper(void);
@@ -198,6 +198,12 @@ public:
 .registerIndex = offsetof(struct i2c_hid_desc, wCommandRegister)
     };
     
+    struct {
+        UInt8 x;
+        UInt8 y;
+        UInt8 buttonMask;
+    } lastmouse;
+    
     I2CDevice* hid_device;
     
     struct csgesture_softc softc;
@@ -215,6 +221,7 @@ public:
     int vendorID();
     int productID();
     
+    void write_report_to_buffer(IOMemoryDescriptor *buffer);
     void write_report_descriptor_to_buffer(IOBufferMemoryDescriptor *buffer);
     
     int i2c_get_slave_address(I2CDevice* hid_device);

--- a/VoodooI2C/VoodooHIDMouseWrapper.cpp
+++ b/VoodooI2C/VoodooHIDMouseWrapper.cpp
@@ -1,0 +1,112 @@
+//
+//  VoodooHIDMouseWrapper.cpp
+//  VoodooI2C
+//
+//  Created by Christopher Luu on 10/7/15.
+//  Copyright © 2015 Alexandre Daoud. All rights reserved.
+//
+
+#include "VoodooHIDMouseWrapper.h"
+#include "VoodooCyapaGen3Device.h"
+
+OSDefineMetaClassAndStructors(VoodooHIDMouseWrapper, IOHIDDevice)
+
+static VoodooI2CCyapaGen3Device* GetOwner(const IOService *us)
+{
+    IOService *prov = us->getProvider();
+    
+    if (prov == NULL)
+        return NULL;
+    return OSDynamicCast(VoodooI2CCyapaGen3Device, prov);
+}
+
+bool VoodooHIDMouseWrapper::start(IOService *provider) {
+    if (OSDynamicCast(VoodooI2CCyapaGen3Device, provider) == NULL)
+        return false;
+
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    setProperty("HIDDefaultBehavior", OSString::withCString("Trackpad"));
+    return IOHIDDevice::start(provider);
+}
+
+IOReturn VoodooHIDMouseWrapper::setProperties(OSObject *properties) {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return kIOReturnUnsupported;
+}
+
+IOReturn VoodooHIDMouseWrapper::newReportDescriptor(IOMemoryDescriptor **descriptor) const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    IOBufferMemoryDescriptor *buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, GetOwner(this)->reportDescriptorLength());
+
+    if (buffer == NULL) return kIOReturnNoResources;
+    GetOwner(this)->write_report_descriptor_to_buffer(buffer);
+    *descriptor = buffer;
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return kIOReturnSuccess;
+}
+
+IOReturn VoodooHIDMouseWrapper::setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return kIOReturnUnsupported;
+}
+
+IOReturn VoodooHIDMouseWrapper::getReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    if (reportType == kIOHIDReportTypeOutput){
+        GetOwner(this)->write_report_to_buffer(report);
+        return kIOReturnSuccess;
+    }
+    return kIOReturnUnsupported;
+}
+
+/*IOReturn VoodooHIDMouseWrapper::handleReport(
+                                        IOMemoryDescriptor * report,
+                                        IOHIDReportType      reportType,
+                                        IOOptionBits         options  ) {
+    return IOHIDDevice::handleReport(report, reportType, options);
+}*/
+
+OSString* VoodooHIDMouseWrapper::newManufacturerString() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSString::withCString("Cypress");
+}
+
+OSNumber* VoodooHIDMouseWrapper::newPrimaryUsageNumber() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSNumber::withNumber(kHIDUsage_GD_Mouse, 32);
+}
+
+OSNumber* VoodooHIDMouseWrapper::newPrimaryUsagePageNumber() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSNumber::withNumber(kHIDPage_GenericDesktop, 32);
+}
+
+OSNumber* VoodooHIDMouseWrapper::newProductIDNumber() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSNumber::withNumber(GetOwner(this)->productID(), 32);
+}
+
+OSString* VoodooHIDMouseWrapper::newProductString() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSString::withCString("Gen3 Trackpad");
+}
+
+OSString* VoodooHIDMouseWrapper::newSerialNumberString() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSString::withCString("1234");
+}
+
+OSString* VoodooHIDMouseWrapper::newTransportString() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSString::withCString("I2C");
+}
+
+OSNumber* VoodooHIDMouseWrapper::newVendorIDNumber() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSNumber::withNumber(GetOwner(this)->vendorID(), 16);
+}
+
+OSNumber* VoodooHIDMouseWrapper::newLocationIDNumber() const {
+    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    return OSNumber::withNumber(123, 32);
+}

--- a/VoodooI2C/VoodooHIDMouseWrapper.h
+++ b/VoodooI2C/VoodooHIDMouseWrapper.h
@@ -1,0 +1,42 @@
+//
+//  VoodooHIDMouseWrapper.h
+//  VoodooI2C
+//
+//  Created by Christopher Luu on 10/7/15.
+//  Copyright © 2015 Alexandre Daoud. All rights reserved.
+//
+
+#ifndef VoodooI2C_VoodooHIDMouseWrapper_h
+#define VoodooI2C_VoodooHIDMouseWrapper_h
+
+#include <IOKit/hid/IOHIDDevice.h>
+
+class VoodooI2CHIDDevice;
+
+class VoodooHIDMouseWrapper : public IOHIDDevice
+{
+    OSDeclareDefaultStructors(VoodooHIDMouseWrapper)
+
+public:
+    virtual bool start(IOService *provider);
+    
+    virtual IOReturn setProperties(OSObject *properties);
+    
+    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const;
+    
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
+    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options);
+    
+    virtual OSString* newManufacturerString() const;
+    virtual OSNumber* newPrimaryUsageNumber() const;
+    virtual OSNumber* newPrimaryUsagePageNumber() const;
+    virtual OSNumber* newProductIDNumber() const;
+    virtual OSString* newProductString() const;
+    virtual OSString* newSerialNumberString() const;
+    virtual OSString* newTransportString() const;
+    virtual OSNumber* newVendorIDNumber() const;
+    
+    virtual OSNumber* newLocationIDNumber() const;
+};
+
+#endif /* VoodooI2C_VoodooHIDMouseWrapper_h */

--- a/VoodooI2C/VoodooI2C.cpp
+++ b/VoodooI2C/VoodooI2C.cpp
@@ -430,7 +430,7 @@ bool VoodooI2C::start(IOService * provider) {
     IORegistryIterator* children;
     IORegistryEntry* child;
     
-
+ 
     
     
     children = IORegistryIterator::iterateOver(_dev->provider, gIOACPIPlane);
@@ -814,6 +814,25 @@ int VoodooI2C::i2c_master_recv(VoodooI2CHIDDevice::I2CDevice I2CDevice, UInt8 *b
     
     msg.addr = I2CDevice.addr;
     msg.flags |= I2C_M_RD;
+    msg.len = count;
+    msg.buf = buf;
+    
+    ret = i2c_transfer(&msg, 1);
+    
+    if (ret) {
+        IOLog("failed!\n");
+    }
+    
+    return (ret == 1) ? count : ret;
+    
+}
+
+int VoodooI2C::i2c_master_send(VoodooI2CHIDDevice::I2CDevice I2CDevice, UInt8 *buf, int count) {
+    struct i2c_msg msg;
+    int ret;
+    
+    msg.addr = I2CDevice.addr;
+    msg.flags |= 0;
     msg.len = count;
     msg.buf = buf;
     

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -7,6 +7,9 @@
 #include <IOKit/IOCommandGate.h>
 #include <string.h>
 #include "VoodooI2CHIDDevice.h"
+#include "VoodooCyapaGen3Device.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
 
 #define STATUS_IDLE 0x0
 #define STATUS_WRITE_IN_PROGRESS 0x1
@@ -277,6 +280,7 @@ public:
     void xferMsgI2C(I2CBus* _dev);
     
     int i2c_master_recv(VoodooI2CHIDDevice::I2CDevice I2CDevice, UInt8 *buf, int count);
+    int i2c_master_send(VoodooI2CHIDDevice::I2CDevice I2CDevice, UInt8 *buf, int count);
     
     void interruptOccured(OSObject* owner, IOInterruptEventSource* src, int intCount);
     


### PR DESCRIPTION
I've fixed up issues with the Cypress driver. I also created a temporary VoodooHIDMouseWrapper to avoid breaking VoodooMouseWrapper for the HID touch screen devices. Trackpad is fully functional in OS X as a mouse. Will need more experimentation to get working as a trackpad and not mouse but it works.