### PR TITLE
Refactor VoodooI2C to have peripherals as a subclass of VoodooI2CDevice. Add 3/4 finger cyapa gestures.

### DIFF
--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -11,10 +11,12 @@
 		AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */ = {isa = PBXBuildFile; fileRef = AC45AFEC1A32543B008E6857 /* VoodooI2C.h */; };
 		AC45AFEF1A32543B008E6857 /* VoodooI2C.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC45AFEE1A32543B008E6857 /* VoodooI2C.cpp */; };
 		ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACF45CF91A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp */; };
-		F158186C1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */; settings = {ASSET_TAGS = (); }; };
-		F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */; settings = {ASSET_TAGS = (); }; };
-		F1AB82D01C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */; settings = {ASSET_TAGS = (); }; };
-		F1AB82D11C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */; settings = {ASSET_TAGS = (); }; };
+		F158186C1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */; };
+		F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */; };
+		F19963091CAD6EE3002E2D29 /* VoodooI2CDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */; };
+		F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */; };
+		F1AB82D01C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */; };
+		F1AB82D11C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +30,8 @@
 		ACF45CF91A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CHIDDevice.cpp; sourceTree = "<group>"; };
 		F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCyapaGen3Device.cpp; sourceTree = "<group>"; };
 		F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCyapaGen3Device.h; sourceTree = "<group>"; };
+		F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CDevice.cpp; sourceTree = "<group>"; };
+		F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooI2CDevice.h; sourceTree = "<group>"; };
 		F1AB82CE1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooHIDMouseWrapper.cpp; sourceTree = "<group>"; };
 		F1AB82CF1C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooHIDMouseWrapper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -65,6 +69,8 @@
 				AC45AFEC1A32543B008E6857 /* VoodooI2C.h */,
 				AC45AFEE1A32543B008E6857 /* VoodooI2C.cpp */,
 				AC45AFEA1A32543B008E6857 /* Supporting Files */,
+				F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */,
+				F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */,
 				ACF45CF81A7FDDD0005C2BBE /* VoodooI2CHIDDevice.h */,
 				ACF45CF91A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp */,
 				F158186A1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp */,
@@ -95,6 +101,7 @@
 				F1AB82D11C1E8F5E003EFE34 /* VoodooHIDMouseWrapper.h in Headers */,
 				F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */,
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
+				F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +176,7 @@
 				308C59881BC61FD20078D1B1 /* VoodooHIDWrapper.cpp in Sources */,
 				ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */,
 				AC45AFEF1A32543B008E6857 /* VoodooI2C.cpp in Sources */,
+				F19963091CAD6EE3002E2D29 /* VoodooI2CDevice.cpp in Sources */,
 				F158186C1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -18,6 +18,7 @@
 #include <IOKit/IOLocks.h>
 #include <IOKit/IOCommandGate.h>
 #include <IOKit/IOTimerEventSource.h>
+#include "VoodooI2CDevice.h"
 
 #define __le16 UInt16
 #define __le32 UInt32
@@ -172,7 +173,7 @@ class VoodooI2C;
 class VoodooHIDMouseWrapper;
 class IOBufferMemoryDescriptor;
 
-class VoodooI2CCyapaGen3Device : public IOService
+class VoodooI2CCyapaGen3Device : public VoodooI2CDevice
 {
     typedef IOService super;
     OSDeclareDefaultStructors(VoodooI2CCyapaGen3Device);
@@ -265,10 +266,13 @@ public:
     
     void update_relative_mouse(char button,
                                char x, char y, char wheelPosition, char wheelHPosition);
+    void update_keyboard(uint8_t shiftKeys, uint8_t *keyCodes);
     
     int distancesq(int delta_x, int delta_y);
     bool ProcessMove(csgesture_softc *sc, int abovethreshold, int iToUse[3]);
     bool ProcessScroll(csgesture_softc *sc, int abovethreshold, int iToUse[3]);
+    bool ProcessThreeFingerSwipe(csgesture_softc *sc, int abovethreshold, int iToUse[3]);
+    
     void TapToClickOrDrag(csgesture_softc *sc, int button);
     void ClearTapDrag(csgesture_softc *sc, int i);
     void ProcessGesture(csgesture_softc *sc);

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -6,6 +6,7 @@
 #include <IOKit/IOLocks.h>
 #include <IOKit/IOCommandGate.h>
 #include <string.h>
+#include "VoodooI2CDevice.h"
 #include "VoodooI2CHIDDevice.h"
 #include "VoodooCyapaGen3Device.h"
 
@@ -251,7 +252,7 @@ public:
     
     
     
-    VoodooI2CHIDDevice* bus_devices[2];
+    VoodooI2CDevice* bus_devices[2];
     int bus_devices_number;
     
 

--- a/VoodooI2C/VoodooI2CDevice.cpp
+++ b/VoodooI2C/VoodooI2CDevice.cpp
@@ -1,0 +1,16 @@
+//
+//  VoodooI2CDevice.cpp
+//  VoodooI2C
+//
+//  Created by coolstar on 3/31/16.
+//  Copyright (c) 2016 Alexandre Daoud. All rights reserved.
+//
+
+#include "VoodooI2CDevice.h"
+
+OSDefineMetaClassAndStructors(VoodooI2CDevice, IOService);
+
+bool VoodooI2CDevice::attach(IOService * provider, IOService* child)
+{
+    return true;
+}

--- a/VoodooI2C/VoodooI2CDevice.h
+++ b/VoodooI2C/VoodooI2CDevice.h
@@ -1,0 +1,21 @@
+//
+//  VoodooI2CDevice.h
+//  VoodooI2C
+//
+//  Created by coolstar on 3/31/16.
+//  Copyright (c) 2016 Alexandre Daoud. All rights reserved.
+//
+
+#ifndef __VoodooI2C__VoodooI2CDevice__
+#define __VoodooI2C__VoodooI2CDevice__
+
+#include <IOKit/IOService.h>
+
+class VoodooI2CDevice : public IOService
+{
+    OSDeclareDefaultStructors(VoodooI2CDevice);
+public:
+    virtual bool attach(IOService * provider, IOService* child);
+};
+
+#endif /* defined(__VoodooI2C__VoodooI2CDevice__) */

--- a/VoodooI2C/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2C/VoodooI2CHIDDevice.cpp
@@ -10,7 +10,7 @@
 #include "VoodooI2C.h"
 #include "VoodooHIDWrapper.h"
 
-OSDefineMetaClassAndStructors(VoodooI2CHIDDevice, IOService);
+OSDefineMetaClassAndStructors(VoodooI2CHIDDevice, VoodooI2CDevice);
 
 bool VoodooI2CHIDDevice::attach(IOService * provider, IOService* child)
 {

--- a/VoodooI2C/VoodooI2CHIDDevice.h
+++ b/VoodooI2C/VoodooI2CHIDDevice.h
@@ -18,6 +18,7 @@
 #include <IOKit/IOLocks.h>
 #include <IOKit/IOCommandGate.h>
 #include <IOKit/IOTimerEventSource.h>
+#include "VoodooI2CDevice.h"
 
 #define __le16 UInt16
 #define __le32 UInt32
@@ -32,7 +33,7 @@ class VoodooI2C;
 class VoodooHIDWrapper;
 class IOBufferMemoryDescriptor;
 
-class VoodooI2CHIDDevice : public IOService
+class VoodooI2CHIDDevice : public VoodooI2CDevice
 {
     typedef IOService super;
     OSDeclareDefaultStructors(VoodooI2CHIDDevice);


### PR DESCRIPTION
Changes for VoodooI2C: Refactor so VoodooI2CHIDDevice and VoodooI2CCyapaGen3Device are subclasses of VoodooI2CDevice

Changes for VoodooCyapaGen3Device: Get Keyboard descriptor working and enable 3/4 finger gestures.