### PR TITLE
Add sleep/resume support to I2C bus driver and Cypress driver.

### DIFF
--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -257,6 +257,8 @@ public:
     void write_report_to_buffer(IOMemoryDescriptor *buffer);
     void write_report_descriptor_to_buffer(IOMemoryDescriptor *buffer);
     
+    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice);
+    
     int i2c_get_slave_address(I2CDevice* hid_device);
     
     void cyapa_set_power_mode(uint8_t power_mode);

--- a/VoodooI2C/VoodooI2C.cpp
+++ b/VoodooI2C/VoodooI2C.cpp
@@ -321,8 +321,6 @@ IOReturn VoodooI2C::setPowerState(unsigned long powerState, IOService *whatDevic
         //Waking up from Sleep
         setI2CPowerState(_dev, true);  //power on I2C bus
         
-        mapI2CMemory(_dev);
-        
         initI2CBus(_dev);  //reinitialize I2C bus
         
         //we've initialised the I2C device, test here

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -11,6 +11,8 @@
 #include "VoodooCyapaGen3Device.h"
 #include "VoodooI2CAtmelMxtScreenDevice.h"
 
+#define kIOPMPowerOff		0
+
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
 
 #define STATUS_IDLE 0x0
@@ -273,6 +275,7 @@ public:
     UInt32 readClearIntrbitsI2C(I2CBus* _dev);
     void releaseAllI2CChildren();
     void setI2CPowerState(I2CBus* _dev, bool enabled);
+    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice);
     virtual bool start(IOService* provider);
     virtual void stop(IOService* provider);
     int waitBusNotBusyI2C(I2CBus* _dev);


### PR DESCRIPTION
Add sleep/resume support to I2C bus driver and Cypress driver. Sleep/wake is working now. Tested with Cypress pad in Acer C720 put to sleep and woken up.

C720 still can't be woken up using the trackpad, but the trackpad works after a sleep/wake cycle once the OS is resumed.