### PR TITLE
Use IOHIPointing for CSGesture-based trackpads, add inertia scroll. Update Elan code.

### DIFF
--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -23,8 +23,8 @@
 		F191539C1D25CE14007972A7 /* csgesture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F191539B1D25CE14007972A7 /* csgesture.cpp */; };
 		F19963091CAD6EE3002E2D29 /* VoodooI2CDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */; };
 		F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */; };
-		F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.cpp */; };
-		F1AB82D11C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.h */; };
+		F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */; };
+		F1AB82D11C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,8 +50,8 @@
 		F1937E791D1F455700F97772 /* csgesture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = csgesture.h; sourceTree = "<group>"; };
 		F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CDevice.cpp; sourceTree = "<group>"; };
 		F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooI2CDevice.h; sourceTree = "<group>"; };
-		F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureMouseWrapper.cpp; sourceTree = "<group>"; };
-		F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCSGestureMouseWrapper.h; sourceTree = "<group>"; };
+		F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureHIDWrapper.cpp; sourceTree = "<group>"; };
+		F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCSGestureHIDWrapper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -145,8 +145,8 @@
 			children = (
 				F1937E791D1F455700F97772 /* csgesture.h */,
 				F191539B1D25CE14007972A7 /* csgesture.cpp */,
-				F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.cpp */,
-				F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.h */,
+				F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */,
+				F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */,
 			);
 			name = "Multitouch Support";
 			sourceTree = "<group>";
@@ -159,7 +159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F110CDBB1D1F3B4D0057BBDB /* VoodooElanTouchpadDevice.h in Headers */,
-				F1AB82D11C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.h in Headers */,
+				F1AB82D11C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h in Headers */,
 				F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */,
 				F153120B1CB96C8300BE6BFC /* VoodooI2CAtmelMxtScreenDevice.h in Headers */,
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
@@ -237,7 +237,7 @@
 			files = (
 				F17D8FF81CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp in Sources */,
 				F153120D1CB9B63B00BE6BFC /* atmel_crc.cpp in Sources */,
-				F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureMouseWrapper.cpp in Sources */,
+				F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp in Sources */,
 				308C59881BC61FD20078D1B1 /* VoodooHIDWrapper.cpp in Sources */,
 				ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */,
 				F153120A1CB96C8300BE6BFC /* VoodooI2CAtmelMxtScreenDevice.cpp in Sources */,

--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		F17D8FF81CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F17D8FF61CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp */; };
 		F17D8FF91CBABF15002F9115 /* VoodooAtmelTouchWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F17D8FF71CBABF15002F9115 /* VoodooAtmelTouchWrapper.h */; };
 		F191539C1D25CE14007972A7 /* csgesture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F191539B1D25CE14007972A7 /* csgesture.cpp */; };
+		F19857311D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */; };
+		F19857321D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F19857301D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h */; };
 		F19963091CAD6EE3002E2D29 /* VoodooI2CDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */; };
 		F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */; };
 		F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */; };
@@ -48,6 +50,8 @@
 		F17D8FF71CBABF15002F9115 /* VoodooAtmelTouchWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooAtmelTouchWrapper.h; sourceTree = "<group>"; };
 		F191539B1D25CE14007972A7 /* csgesture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = csgesture.cpp; sourceTree = "<group>"; };
 		F1937E791D1F455700F97772 /* csgesture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = csgesture.h; sourceTree = "<group>"; };
+		F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureHIPointingWrapper.cpp; sourceTree = "<group>"; };
+		F19857301D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCSGestureHIPointingWrapper.h; sourceTree = "<group>"; };
 		F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CDevice.cpp; sourceTree = "<group>"; };
 		F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooI2CDevice.h; sourceTree = "<group>"; };
 		F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureHIDWrapper.cpp; sourceTree = "<group>"; };
@@ -147,6 +151,8 @@
 				F191539B1D25CE14007972A7 /* csgesture.cpp */,
 				F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */,
 				F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */,
+				F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */,
+				F19857301D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h */,
 			);
 			name = "Multitouch Support";
 			sourceTree = "<group>";
@@ -165,6 +171,7 @@
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
 				F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */,
 				F17D8FF91CBABF15002F9115 /* VoodooAtmelTouchWrapper.h in Headers */,
+				F19857321D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,6 +248,7 @@
 				308C59881BC61FD20078D1B1 /* VoodooHIDWrapper.cpp in Sources */,
 				ACF45CFA1A7FDE76005C2BBE /* VoodooI2CHIDDevice.cpp in Sources */,
 				F153120A1CB96C8300BE6BFC /* VoodooI2CAtmelMxtScreenDevice.cpp in Sources */,
+				F19857311D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp in Sources */,
 				F191539C1D25CE14007972A7 /* csgesture.cpp in Sources */,
 				AC45AFEF1A32543B008E6857 /* VoodooI2C.cpp in Sources */,
 				F110CDBA1D1F3B4D0057BBDB /* VoodooElanTouchpadDevice.cpp in Sources */,

--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */; };
 		F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */; };
 		F1AB82D11C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */; };
+		F1FA896C1D7FAAC90019F9CF /* AverageClasses.h in Headers */ = {isa = PBXBuildFile; fileRef = F1FA896B1D7FAAC90019F9CF /* AverageClasses.h */; };
+		F1FA896F1D7FAAF10019F9CF /* csgesturescroll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1FA896D1D7FAAF10019F9CF /* csgesturescroll.cpp */; };
+		F1FA89701D7FAAF10019F9CF /* csgesturescroll.h in Headers */ = {isa = PBXBuildFile; fileRef = F1FA896E1D7FAAF10019F9CF /* csgesturescroll.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +59,10 @@
 		F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooI2CDevice.h; sourceTree = "<group>"; };
 		F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureHIDWrapper.cpp; sourceTree = "<group>"; };
 		F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCSGestureHIDWrapper.h; sourceTree = "<group>"; };
+		F1FA896B1D7FAAC90019F9CF /* AverageClasses.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AverageClasses.h; sourceTree = "<group>"; };
+		F1FA896D1D7FAAF10019F9CF /* csgesturescroll.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = csgesturescroll.cpp; sourceTree = "<group>"; };
+		F1FA896E1D7FAAF10019F9CF /* csgesturescroll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = csgesturescroll.h; sourceTree = "<group>"; };
+		F1FA89711D7FBD4F0019F9CF /* csgesture-softc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "csgesture-softc.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,8 +154,12 @@
 		F1937E781D1F454B00F97772 /* Multitouch Support */ = {
 			isa = PBXGroup;
 			children = (
+				F1FA896B1D7FAAC90019F9CF /* AverageClasses.h */,
 				F1937E791D1F455700F97772 /* csgesture.h */,
+				F1FA89711D7FBD4F0019F9CF /* csgesture-softc.h */,
 				F191539B1D25CE14007972A7 /* csgesture.cpp */,
+				F1FA896D1D7FAAF10019F9CF /* csgesturescroll.cpp */,
+				F1FA896E1D7FAAF10019F9CF /* csgesturescroll.h */,
 				F1AB82CE1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp */,
 				F1AB82CF1C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.h */,
 				F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */,
@@ -170,8 +181,10 @@
 				F153120B1CB96C8300BE6BFC /* VoodooI2CAtmelMxtScreenDevice.h in Headers */,
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
 				F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */,
+				F1FA896C1D7FAAC90019F9CF /* AverageClasses.h in Headers */,
 				F17D8FF91CBABF15002F9115 /* VoodooAtmelTouchWrapper.h in Headers */,
 				F19857321D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h in Headers */,
+				F1FA89701D7FAAF10019F9CF /* csgesturescroll.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -242,6 +255,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1FA896F1D7FAAF10019F9CF /* csgesturescroll.cpp in Sources */,
 				F17D8FF81CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp in Sources */,
 				F153120D1CB9B63B00BE6BFC /* atmel_crc.cpp in Sources */,
 				F1AB82D01C1E8F5E003EFE34 /* VoodooCSGestureHIDWrapper.cpp in Sources */,

--- a/VoodooI2C/AverageClasses.h
+++ b/VoodooI2C/AverageClasses.h
@@ -1,0 +1,129 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// SimpleAverage Class Declaration
+//
+
+#ifndef SimpleAverage_h
+#define SimpleAverage_h
+
+template <class T, int N>
+class SimpleAverage
+{
+private:
+	T m_buffer[N];
+	int m_count;
+	int m_sum;
+	int m_index;
+
+public:
+	inline SimpleAverage() { reset(); }
+	T filter(T data)
+	{
+		// add new entry to sum
+		m_sum += data;
+		// if full buffer, then we are overwriting, so subtract old from sum
+		if (m_count == N)
+			m_sum -= m_buffer[m_index];
+		// new entry into buffer
+		m_buffer[m_index] = data;
+		// move index to next position with wrap around
+		if (++m_index >= N)
+			m_index = 0;
+		// keep count moving until buffer is full
+		if (m_count < N)
+			++m_count;
+		// return average of current items
+		return m_sum / m_count;
+	}
+	inline void reset()
+	{
+		m_count = 0;
+		m_sum = 0;
+		m_index = 0;
+	}
+	inline int count() { return m_count; }
+	inline int sum() { return m_sum; }
+	T oldest()
+	{
+		// undefined if nothing in here, return zero
+		if (m_count == 0)
+			return 0;
+		// if it is not full, oldest is at index 0
+		// if full, it is right where the next one goes
+		if (m_count < N)
+			return m_buffer[0];
+		else
+			return m_buffer[m_index];
+	}
+	T newest()
+	{
+		// undefined if nothing in here, return zero
+		if (m_count == 0)
+			return 0;
+		// newest is index - 1, with wrap
+		int index = m_index;
+		if (--index < 0)
+			index = m_count - 1;
+		return m_buffer[index];
+	}
+	T average()
+	{
+		if (m_count == 0)
+			return 0;
+		return m_sum / m_count;
+	}
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// DecayingAverage Class Declaration
+//
+
+template <class T, class TT, int N1, int N2, int D>
+class DecayingAverage
+{
+private:
+	T m_last;
+	bool m_lastvalid;
+
+public:
+	inline DecayingAverage() { reset(); }
+	T filter(T data, int fingers)
+	{
+		TT result = data;
+		TT last = m_last;
+		if (m_lastvalid)
+			result = (result * N1) / D + (last * N2) / D;
+		m_lastvalid = true;
+		m_last = (T)result;
+		return m_last;
+	}
+	inline void reset()
+	{
+		m_lastvalid = false;
+	}
+};
+
+template <class T, class TT, int N1, int N2, int D>
+class UndecayAverage
+{
+private:
+	T m_last;
+	bool m_lastvalid;
+
+public:
+	inline UndecayAverage() { reset(); }
+	T filter(T data)
+	{
+		TT result = data;
+		TT last = m_last;
+		if (m_lastvalid)
+			result = (result * D) / N1 - (last * N2) / N1;
+		m_lastvalid = true;
+		m_last = (T)data;
+		return (T)result;
+	}
+	inline void reset()
+	{
+		m_lastvalid = false;
+	}
+};
+#endif

--- a/VoodooI2C/VoodooAtmelTouchWrapper.h
+++ b/VoodooI2C/VoodooAtmelTouchWrapper.h
@@ -18,25 +18,25 @@ class VoodooAtmelTouchWrapper : public IOHIDDevice
     OSDeclareDefaultStructors(VoodooAtmelTouchWrapper)
 
 public:
-    virtual bool start(IOService *provider);
+    virtual bool start(IOService *provider) override;
     
-    virtual IOReturn setProperties(OSObject *properties);
+    virtual IOReturn setProperties(OSObject *properties) override;
     
-    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const;
+    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
     
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
-    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
+    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options) override;
     
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newPrimaryUsageNumber() const;
-    virtual OSNumber* newPrimaryUsagePageNumber() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSString* newProductString() const;
-    virtual OSString* newSerialNumberString() const;
-    virtual OSString* newTransportString() const;
-    virtual OSNumber* newVendorIDNumber() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newPrimaryUsageNumber() const override;
+    virtual OSNumber* newPrimaryUsagePageNumber() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSString* newProductString() const override;
+    virtual OSString* newSerialNumberString() const override;
+    virtual OSString* newTransportString() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
     
-    virtual OSNumber* newLocationIDNumber() const;
+    virtual OSNumber* newLocationIDNumber() const override;
 };
 
 #endif /* VoodooI2C_VoodooCyapaMouseWrapper_h */

--- a/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
@@ -1,28 +1,28 @@
 //
-//  VoodooCyapaMouseWrapper.cpp
+//  VoodooCSGestureHIDWrapper.cpp
 //  VoodooI2C
 //
 //  Created by Christopher Luu on 10/7/15.
 //  Copyright © 2015 Alexandre Daoud. All rights reserved.
 //
 
-#include "VoodooCSGestureMouseWrapper.h"
+#include "VoodooCSGestureHIDWrapper.h"
 #include "csgesture.h"
 
-OSDefineMetaClassAndStructors(VoodooCSGestureMouseWrapper, IOHIDDevice)
+OSDefineMetaClassAndStructors(VoodooCSGestureHIDWrapper, IOHIDDevice)
 
-bool VoodooCSGestureMouseWrapper::start(IOService *provider) {
+bool VoodooCSGestureHIDWrapper::start(IOService *provider) {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     setProperty("HIDDefaultBehavior", OSString::withCString("Trackpad"));
     return IOHIDDevice::start(provider);
 }
 
-IOReturn VoodooCSGestureMouseWrapper::setProperties(OSObject *properties) {
+IOReturn VoodooCSGestureHIDWrapper::setProperties(OSObject *properties) {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return kIOReturnUnsupported;
 }
 
-IOReturn VoodooCSGestureMouseWrapper::newReportDescriptor(IOMemoryDescriptor **descriptor) const {
+IOReturn VoodooCSGestureHIDWrapper::newReportDescriptor(IOMemoryDescriptor **descriptor) const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     IOBufferMemoryDescriptor *buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, gestureEngine->reportDescriptorLength());
 
@@ -33,12 +33,12 @@ IOReturn VoodooCSGestureMouseWrapper::newReportDescriptor(IOMemoryDescriptor **d
     return kIOReturnSuccess;
 }
 
-IOReturn VoodooCSGestureMouseWrapper::setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
+IOReturn VoodooCSGestureHIDWrapper::setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return kIOReturnUnsupported;
 }
 
-IOReturn VoodooCSGestureMouseWrapper::getReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
+IOReturn VoodooCSGestureHIDWrapper::getReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     if (reportType == kIOHIDReportTypeOutput){
         gestureEngine->write_report_to_buffer(report);
@@ -54,47 +54,47 @@ IOReturn VoodooCSGestureMouseWrapper::getReport(IOMemoryDescriptor *report, IOHI
     return IOHIDDevice::handleReport(report, reportType, options);
 }*/
 
-OSString* VoodooCSGestureMouseWrapper::newManufacturerString() const {
+OSString* VoodooCSGestureHIDWrapper::newManufacturerString() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("CSGesture");
 }
 
-OSNumber* VoodooCSGestureMouseWrapper::newPrimaryUsageNumber() const {
+OSNumber* VoodooCSGestureHIDWrapper::newPrimaryUsageNumber() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(kHIDUsage_GD_Mouse, 32);
 }
 
-OSNumber* VoodooCSGestureMouseWrapper::newPrimaryUsagePageNumber() const {
+OSNumber* VoodooCSGestureHIDWrapper::newPrimaryUsagePageNumber() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(kHIDPage_GenericDesktop, 32);
 }
 
-OSNumber* VoodooCSGestureMouseWrapper::newProductIDNumber() const {
+OSNumber* VoodooCSGestureHIDWrapper::newProductIDNumber() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(gestureEngine->productID, 32);
 }
 
-OSString* VoodooCSGestureMouseWrapper::newProductString() const {
+OSString* VoodooCSGestureHIDWrapper::newProductString() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("Trackpad");
 }
 
-OSString* VoodooCSGestureMouseWrapper::newSerialNumberString() const {
+OSString* VoodooCSGestureHIDWrapper::newSerialNumberString() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("1234");
 }
 
-OSString* VoodooCSGestureMouseWrapper::newTransportString() const {
+OSString* VoodooCSGestureHIDWrapper::newTransportString() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("I2C");
 }
 
-OSNumber* VoodooCSGestureMouseWrapper::newVendorIDNumber() const {
+OSNumber* VoodooCSGestureHIDWrapper::newVendorIDNumber() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(gestureEngine->vendorID, 16);
 }
 
-OSNumber* VoodooCSGestureMouseWrapper::newLocationIDNumber() const {
+OSNumber* VoodooCSGestureHIDWrapper::newLocationIDNumber() const {
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(123, 32);
 }

--- a/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
@@ -12,34 +12,27 @@
 OSDefineMetaClassAndStructors(VoodooCSGestureHIDWrapper, IOHIDDevice)
 
 bool VoodooCSGestureHIDWrapper::start(IOService *provider) {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     setProperty("HIDDefaultBehavior", OSString::withCString("Trackpad"));
     return IOHIDDevice::start(provider);
 }
 
 IOReturn VoodooCSGestureHIDWrapper::setProperties(OSObject *properties) {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return kIOReturnUnsupported;
 }
 
-IOReturn VoodooCSGestureHIDWrapper::newReportDescriptor(IOMemoryDescriptor **descriptor) const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
-    IOBufferMemoryDescriptor *buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, gestureEngine->reportDescriptorLength());
+IOReturn VoodooCSGestureHIDWrapper::newReportDescriptor(IOMemoryDescriptor **descriptor) const {    IOBufferMemoryDescriptor *buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, gestureEngine->reportDescriptorLength());
 
     if (buffer == NULL) return kIOReturnNoResources;
     gestureEngine->write_report_descriptor_to_buffer(buffer);
     *descriptor = buffer;
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return kIOReturnSuccess;
 }
 
 IOReturn VoodooCSGestureHIDWrapper::setReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return kIOReturnUnsupported;
 }
 
 IOReturn VoodooCSGestureHIDWrapper::getReport(IOMemoryDescriptor *report, IOHIDReportType reportType, IOOptionBits options) {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     if (reportType == kIOHIDReportTypeOutput){
         gestureEngine->write_report_to_buffer(report);
         return kIOReturnSuccess;
@@ -47,54 +40,38 @@ IOReturn VoodooCSGestureHIDWrapper::getReport(IOMemoryDescriptor *report, IOHIDR
     return kIOReturnUnsupported;
 }
 
-/*IOReturn VoodooCyapaMouseWrapper::handleReport(
-                                        IOMemoryDescriptor * report,
-                                        IOHIDReportType      reportType,
-                                        IOOptionBits         options  ) {
-    return IOHIDDevice::handleReport(report, reportType, options);
-}*/
-
 OSString* VoodooCSGestureHIDWrapper::newManufacturerString() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("CSGesture");
 }
 
 OSNumber* VoodooCSGestureHIDWrapper::newPrimaryUsageNumber() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(kHIDUsage_GD_Mouse, 32);
 }
 
 OSNumber* VoodooCSGestureHIDWrapper::newPrimaryUsagePageNumber() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(kHIDPage_GenericDesktop, 32);
 }
 
 OSNumber* VoodooCSGestureHIDWrapper::newProductIDNumber() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(gestureEngine->productID, 32);
 }
 
 OSString* VoodooCSGestureHIDWrapper::newProductString() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("Trackpad");
 }
 
 OSString* VoodooCSGestureHIDWrapper::newSerialNumberString() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("1234");
 }
 
 OSString* VoodooCSGestureHIDWrapper::newTransportString() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSString::withCString("I2C");
 }
 
 OSNumber* VoodooCSGestureHIDWrapper::newVendorIDNumber() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(gestureEngine->vendorID, 16);
 }
 
 OSNumber* VoodooCSGestureHIDWrapper::newLocationIDNumber() const {
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     return OSNumber::withNumber(123, 32);
 }

--- a/VoodooI2C/VoodooCSGestureHIDWrapper.h
+++ b/VoodooI2C/VoodooCSGestureHIDWrapper.h
@@ -20,25 +20,25 @@ class VoodooCSGestureHIDWrapper : public IOHIDDevice
 public:
     CSGesture *gestureEngine;
     
-    virtual bool start(IOService *provider);
+    virtual bool start(IOService *provider) override;
     
-    virtual IOReturn setProperties(OSObject *properties);
+    virtual IOReturn setProperties(OSObject *properties) override;
     
-    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const;
+    virtual IOReturn newReportDescriptor(IOMemoryDescriptor **descriptor) const override;
     
-    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0);
-    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options);
+    virtual IOReturn setReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options=0) override;
+    virtual IOReturn getReport(IOMemoryDescriptor *report,IOHIDReportType reportType,IOOptionBits options) override;
     
-    virtual OSString* newManufacturerString() const;
-    virtual OSNumber* newPrimaryUsageNumber() const;
-    virtual OSNumber* newPrimaryUsagePageNumber() const;
-    virtual OSNumber* newProductIDNumber() const;
-    virtual OSString* newProductString() const;
-    virtual OSString* newSerialNumberString() const;
-    virtual OSString* newTransportString() const;
-    virtual OSNumber* newVendorIDNumber() const;
+    virtual OSString* newManufacturerString() const override;
+    virtual OSNumber* newPrimaryUsageNumber() const override;
+    virtual OSNumber* newPrimaryUsagePageNumber() const override;
+    virtual OSNumber* newProductIDNumber() const override;
+    virtual OSString* newProductString() const override;
+    virtual OSString* newSerialNumberString() const override;
+    virtual OSString* newTransportString() const override;
+    virtual OSNumber* newVendorIDNumber() const override;
     
-    virtual OSNumber* newLocationIDNumber() const;
+    virtual OSNumber* newLocationIDNumber() const override;
 };
 
 #endif /* VoodooI2C_VoodooCSGestureHIDWrapper_h */

--- a/VoodooI2C/VoodooCSGestureHIDWrapper.h
+++ b/VoodooI2C/VoodooCSGestureHIDWrapper.h
@@ -1,22 +1,22 @@
 //
-//  VoodooCSGestureMouseWrapper.h
+//  VoodooCSGestureHIDWrapper.h
 //  VoodooI2C
 //
 //  Created by Christopher Luu on 10/7/15.
 //  Copyright © 2015 Alexandre Daoud. All rights reserved.
 //
 
-#ifndef VoodooI2C_VoodooCSGestureMouseWrapper_h
-#define VoodooI2C_VoodooCSGestureMouseWrapper_h
+#ifndef VoodooI2C_VoodooCSGestureHIDWrapper_h
+#define VoodooI2C_VoodooCSGestureHIDWrapper_h
 
 #include <IOKit/hid/IOHIDDevice.h>
 
 class VoodooI2CHIDDevice;
 class CSGesture;
 
-class VoodooCSGestureMouseWrapper : public IOHIDDevice
+class VoodooCSGestureHIDWrapper : public IOHIDDevice
 {
-    OSDeclareDefaultStructors(VoodooCSGestureMouseWrapper)
+    OSDeclareDefaultStructors(VoodooCSGestureHIDWrapper)
 public:
     CSGesture *gestureEngine;
     
@@ -41,4 +41,4 @@ public:
     virtual OSNumber* newLocationIDNumber() const;
 };
 
-#endif /* VoodooI2C_VoodooCSGestureMouseWrapper_h */
+#endif /* VoodooI2C_VoodooCSGestureHIDWrapper_h */

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -55,10 +55,11 @@ bool VoodooCSGestureHIPointingWrapper::start(IOService *provider){
     // speed adjustments from the mouse prefs panel have no effect.
     //
     
-    int prodID = 547;
+    //int prodID = 0x223; //old settings pane (VoodooPS2)
+    int prodID = 0x0262; //product id from newer Macbook
     setProperty("ProductID", prodID, sizeof(prodID) * 8);
     
-    int vendorID = 1452;
+    int vendorID = 0x05ac;
     setProperty("VendorID", vendorID, sizeof(vendorID) * 8);
     
     //Need to fake Vendor and Product ID to pull up the trackpad settings pane
@@ -87,18 +88,31 @@ void VoodooCSGestureHIPointingWrapper::updateRelativeMouse(int dx, int dy, int b
 void VoodooCSGestureHIPointingWrapper::updateScroll(short dy, short dx, short dz){
     uint64_t now_abs;
     clock_get_uptime(&now_abs);
+    if (!horizontalScroll)
+        dx = 0;
     dispatchScrollWheelEvent(dy, dx, dz, now_abs);
 }
 
 IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict)
 {
-    OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
-    OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
-    OSNumber *draglock = OSDynamicCast(OSNumber, dict->getObject("DragLock"));
-    OSNumber *hscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
-    OSNumber *vscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadScroll"));
-    OSNumber *eaccell  = OSDynamicCast(OSNumber, dict->getObject("HIDTrackpadScrollAcceleration"));
+ 
+    /*Known Keys:
+        HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
+    OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+    if (clicking){
+        gesturerec->softc->settings.tapToClickEnabled = clicking->unsigned32BitValue() & 0x1;
+    }
+    
+    OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+    if (dragging){
+        gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
+    }
+    
+    OSNumber *hscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
+    if (hscroll){
+        horizontalScroll = hscroll->unsigned32BitValue() & 0x1;
+    }
     return super::setParamProperties(dict);
 }
 

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -109,6 +109,8 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
         gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
     }
     
+    gesturerec->softc->settings.multiFingerTap = true;
+    
     OSNumber *hscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
     if (hscroll){
         horizontalScroll = hscroll->unsigned32BitValue() & 0x1;

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -1,0 +1,104 @@
+//
+//  VoodooCSGestureHIPointingWrapper.cpp
+//  VoodooI2C
+//
+//  Created by CoolStar on 9/6/16.
+//  Copyright © 2016 CoolStar. All rights reserved.
+//
+
+#include <IOKit/IOLib.h>
+#include <IOKit/hidsystem/IOHIDParameter.h>
+#include "VoodooCSGestureHIPointingWrapper.h"
+
+OSDefineMetaClassAndStructors(VoodooCSGestureHIPointingWrapper, IOHIPointing);
+
+UInt32 VoodooCSGestureHIPointingWrapper::deviceType()
+{
+    return NX_EVS_DEVICE_TYPE_MOUSE;
+}
+
+UInt32 VoodooCSGestureHIPointingWrapper::interfaceID()
+{
+    return NX_EVS_DEVICE_INTERFACE_BUS_ACE;
+}
+
+IOItemCount VoodooCSGestureHIPointingWrapper::buttonCount(){
+    return 2;
+};
+
+IOFixed VoodooCSGestureHIPointingWrapper::resolution(){
+    return (300) << 16;
+};
+
+bool VoodooCSGestureHIPointingWrapper::init(){
+    if (!super::init())
+        return false;
+    
+    return true;
+}
+
+bool VoodooCSGestureHIPointingWrapper::start(IOService *provider){
+    if (!super::start(provider))
+        return false;
+    
+    int enabledProperty = 1;
+    setProperty("Clicking", enabledProperty,
+                sizeof(enabledProperty) * 8);
+    setProperty("TrackpadScroll", enabledProperty,
+                sizeof(enabledProperty) * 8);
+    setProperty("TrackpadHorizScroll", enabledProperty,
+                sizeof(enabledProperty) * 8);
+    
+    //
+    // Must add this property to let our superclass know that it should handle
+    // trackpad acceleration settings from user space.  Without this, tracking
+    // speed adjustments from the mouse prefs panel have no effect.
+    //
+    
+    int prodID = 547;
+    setProperty("ProductID", prodID, sizeof(prodID) * 8);
+    
+    int vendorID = 1452;
+    setProperty("VendorID", vendorID, sizeof(vendorID) * 8);
+    
+    //Need to fake Vendor and Product ID to pull up the trackpad settings pane
+    
+    setProperty(kIOHIDPointerAccelerationTypeKey, kIOHIDTrackpadAccelerationType);
+    setProperty(kIOHIDScrollAccelerationTypeKey, kIOHIDTrackpadScrollAccelerationKey);
+    setProperty(kIOHIDScrollResolutionKey, 800 << 16, 32);
+    
+    return true;
+}
+
+void VoodooCSGestureHIPointingWrapper::stop(IOService *provider){
+    super::stop(provider);
+}
+
+void VoodooCSGestureHIPointingWrapper::updateRelativeMouse(int dx, int dy, int buttons){
+    // 0x1 = left button
+    // 0x2 = right button
+    // 0x4 = middle button
+    
+    uint64_t now_abs;
+    clock_get_uptime(&now_abs);
+    dispatchRelativePointerEvent(dx, dy, buttons, now_abs);
+}
+
+void VoodooCSGestureHIPointingWrapper::updateScroll(short dy, short dx, short dz){
+    uint64_t now_abs;
+    clock_get_uptime(&now_abs);
+    dispatchScrollWheelEvent(dy, dx, dz, now_abs);
+}
+
+IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict)
+{
+    OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+    OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+    OSNumber *draglock = OSDynamicCast(OSNumber, dict->getObject("DragLock"));
+    OSNumber *hscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
+    OSNumber *vscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadScroll"));
+    OSNumber *eaccell  = OSDynamicCast(OSNumber, dict->getObject("HIDTrackpadScrollAcceleration"));
+    
+    return super::setParamProperties(dict);
+}
+

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
@@ -1,0 +1,38 @@
+//
+//  VoodooCSGestureHIPointingWrapper.hpp
+//  VoodooI2C
+//
+//  Created by CoolStar on 9/6/16.
+//  Copyright © 2016 CoolStar. All rights reserved.
+//
+
+#ifndef VoodooCSGestureHIPointingWrapper_h
+#define VoodooCSGestureHIPointingWrapper_h
+
+#include <IOKit/hidsystem/IOHIPointing.h>
+
+class VoodooCSGestureHIPointingWrapper : public IOHIPointing
+{
+    typedef IOHIPointing super;
+    OSDeclareDefaultStructors(VoodooCSGestureHIPointingWrapper);
+    
+protected:
+    virtual IOItemCount buttonCount();
+    virtual IOFixed resolution();
+    
+public:
+    virtual bool init();
+    
+    virtual bool start(IOService *provider);
+    virtual void stop(IOService *provider);
+    
+    virtual UInt32 deviceType();
+    virtual UInt32 interfaceID();
+    
+    virtual IOReturn setParamProperties(OSDictionary *dict);
+    
+    void updateRelativeMouse(int dx, int dy, int buttons);
+    void updateScroll(short dy, short dx, short dz);
+};
+
+#endif /* VoodooCSGestureHIPointingWrapper_h */

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
@@ -10,17 +10,23 @@
 #define VoodooCSGestureHIPointingWrapper_h
 
 #include <IOKit/hidsystem/IOHIPointing.h>
+#include "csgesture.h"
 
 class VoodooCSGestureHIPointingWrapper : public IOHIPointing
 {
     typedef IOHIPointing super;
     OSDeclareDefaultStructors(VoodooCSGestureHIPointingWrapper);
     
+private:
+    bool horizontalScroll;
+    
 protected:
     virtual IOItemCount buttonCount();
     virtual IOFixed resolution();
     
 public:
+    CSGesture *gesturerec;
+    
     virtual bool init();
     
     virtual bool start(IOService *provider);

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.h
@@ -21,21 +21,21 @@ private:
     bool horizontalScroll;
     
 protected:
-    virtual IOItemCount buttonCount();
-    virtual IOFixed resolution();
+    virtual IOItemCount buttonCount() override;
+    virtual IOFixed resolution() override;
     
 public:
     CSGesture *gesturerec;
     
-    virtual bool init();
+    virtual bool init() override;
     
-    virtual bool start(IOService *provider);
-    virtual void stop(IOService *provider);
+    virtual bool start(IOService *provider) override;
+    virtual void stop(IOService *provider) override;
     
-    virtual UInt32 deviceType();
-    virtual UInt32 interfaceID();
+    virtual UInt32 deviceType() override;
+    virtual UInt32 interfaceID() override;
     
-    virtual IOReturn setParamProperties(OSDictionary *dict);
+    virtual IOReturn setParamProperties(OSDictionary *dict) override;
     
     void updateRelativeMouse(int dx, int dy, int buttons);
     void updateScroll(short dy, short dx, short dz);

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -282,6 +282,7 @@ void VoodooI2CCyapaGen3Device::initialize_wrapper(void) {
     _wrapper = new CSGesture;
     _wrapper->vendorID = 'pyaC';
     _wrapper->productID = 'rtyC';
+    _wrapper->softc = &softc;
     _wrapper->initialize_wrapper(this);
 }
 
@@ -344,6 +345,10 @@ IOReturn VoodooI2CCyapaGen3Device::setPowerState(unsigned long powerState, IOSer
             hid_device->timerSource->release();
             hid_device->timerSource = NULL;
         }
+        
+        if (_wrapper)
+            _wrapper->prepareToSleep();
+        
         IOLog("%s::Going to Sleep!\n", getName());
     } else {
         //Waking up from Sleep
@@ -352,6 +357,9 @@ IOReturn VoodooI2CCyapaGen3Device::setPowerState(unsigned long powerState, IOSer
             hid_device->workLoop->addEventSource(hid_device->timerSource);
             hid_device->timerSource->setTimeoutMS(10);
         }
+        
+        if (_wrapper)
+            _wrapper->wakeFromSleep();
         
         IOLog("%s::Woke up from Sleep!\n", getName());
     }

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -142,8 +142,7 @@ void VoodooI2CCyapaGen3Device::cyapa_set_power_mode(uint8_t power_mode)
 int VoodooI2CCyapaGen3Device::initHIDDevice(I2CDevice *hid_device) {
     PMinit();
     
-    int ret;
-    UInt16 hidRegister;
+    int ret = 0;
     
     uint8_t bl_exit[] = {
         0x00, 0x00, 0xff, 0xa5, 0x00, 0x01,

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -4,7 +4,7 @@
 //
 //  Created by CoolStar on 12/13/15.
 //  Copyright © 2015 CoolStar. All rights reserved.
-//  ported from crostrackpad 3.0 beta 9.4 for Windows
+//  ported from crostrackpad 3.0 for Windows
 //
 
 #include "VoodooCyapaGen3Device.h"

--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -4,7 +4,7 @@
 //
 //  Created by CoolStar on 12/13/15.
 //  Copyright © 2015 CoolStar. All rights reserved.
-//  ported from crostrackpad 3.0 beta 9.4 for Windows
+//  ported from crostrackpad 3.0 for Windows
 //
 
 #ifndef VoodooI2C_VoodooCyapaGen3Device_h

--- a/VoodooI2C/VoodooCyapaGen3Device.h
+++ b/VoodooI2C/VoodooCyapaGen3Device.h
@@ -125,9 +125,9 @@ protected:
     VoodooI2C* _controller;
     
 public:
-    virtual bool attach(IOService * provider, IOService* child);
-    virtual void detach(IOService * provider);
-    void stop(IOService* device);
+    virtual bool attach(IOService * provider, IOService* child) override;
+    virtual void detach(IOService * provider) override;
+    void stop(IOService* device) override;
     
     
     typedef struct {
@@ -180,7 +180,7 @@ public:
     
     void get_input(OSObject* owner, IOTimerEventSource* sender);
     
-    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice);
+    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice) override;
     
     int i2c_get_slave_address(I2CDevice* hid_device);
     

--- a/VoodooI2C/VoodooElanTouchpadDevice.cpp
+++ b/VoodooI2C/VoodooElanTouchpadDevice.cpp
@@ -175,8 +175,7 @@ void VoodooI2CElanTouchpadDevice::detach( IOService * provider )
 int VoodooI2CElanTouchpadDevice::initHIDDevice(I2CDevice *hid_device) {
     PMinit();
     
-    int ret;
-    UInt16 hidRegister;
+    int ret = 0;
     
     elan_i2c_write_cmd(ETP_I2C_STAND_CMD, ETP_I2C_RESET);
     

--- a/VoodooI2C/VoodooElanTouchpadDevice.cpp
+++ b/VoodooI2C/VoodooElanTouchpadDevice.cpp
@@ -2,9 +2,9 @@
 //  VoodooElanTouchpadDevice.cpp
 //  VoodooI2C
 //
-//  Created by CoolStar on 12/13/15.
-//  Copyright © 2015 CoolStar. All rights reserved.
-//  ported from crostrackpad-elan 3.0 beta 9.4 for Windows
+//  Created by CoolStar on 6/25/16.
+//  Copyright © 2016 CoolStar. All rights reserved.
+//  ported from crostrackpad-elan 3.0 for Windows
 //
 
 #include "VoodooElanTouchpadDevice.h"
@@ -52,10 +52,15 @@ void VoodooI2CElanTouchpadDevice::TrackpadRawInput(struct csgesture_softc *sc, u
             //map to cypress coordinates
             //pos_y = 1500 - pos_y;
             pos_y = sc->phyy - pos_y;
-            pos_x *= 2;
+            /*pos_x *= 2;
             pos_x /= 7;
             pos_y *= 2;
-            pos_y /= 7;
+            pos_y /= 7;*/
+            pos_x *= 10;
+            pos_x /= hw_res_x;
+            
+            pos_y *= 10;
+            pos_y /= hw_res_y;
             
             
             /*
@@ -220,6 +225,14 @@ int VoodooI2CElanTouchpadDevice::initHIDDevice(I2CDevice *hid_device) {
     uint8_t x_traces = val2[0];
     uint8_t y_traces = val2[1];
     
+    elan_i2c_read_cmd(ETP_I2C_RESOLUTION_CMD, val2);
+    
+    hw_res_x = val2[0];
+    hw_res_y = val2[1];
+    
+    hw_res_x = (hw_res_x * 10 + 790) * 10 / 254;
+    hw_res_y = (hw_res_y * 10 + 790) * 10 / 254;
+    
     csgesture_softc *sc = &softc;
     
     sprintf(sc->product_id, "%d.0", prodid);
@@ -228,11 +241,14 @@ int VoodooI2CElanTouchpadDevice::initHIDDevice(I2CDevice *hid_device) {
     sc->resx = max_x;
     sc->resy = max_y;
     
-    sc->resx *= 2;
+    /*sc->resx *= 2;
     sc->resx /= 7;
     
     sc->resy *= 2;
-    sc->resy /= 7;
+    sc->resy /= 7;*/
+    
+    sc->resx = max_x * 10 / hw_res_x;
+    sc->resy = max_y * 10 / hw_res_y;
     
     sc->phyx = max_x;
     sc->phyy = max_y;

--- a/VoodooI2C/VoodooElanTouchpadDevice.cpp
+++ b/VoodooI2C/VoodooElanTouchpadDevice.cpp
@@ -326,6 +326,7 @@ void VoodooI2CElanTouchpadDevice::initialize_wrapper(void) {
     _wrapper = new CSGesture;
     _wrapper->vendorID = 'nalE';
     _wrapper->productID = 'dptE';
+    _wrapper->softc = &softc;
     _wrapper->initialize_wrapper(this);
 }
 
@@ -447,6 +448,10 @@ IOReturn VoodooI2CElanTouchpadDevice::setPowerState(unsigned long powerState, IO
             hid_device->timerSource->release();
             hid_device->timerSource = NULL;
         }
+        
+        if (_wrapper)
+            _wrapper->prepareToSleep();
+        
         IOLog("%s::Going to Sleep!\n", getName());
     } else {
         //Waking up from Sleep
@@ -455,6 +460,9 @@ IOReturn VoodooI2CElanTouchpadDevice::setPowerState(unsigned long powerState, IO
             hid_device->workLoop->addEventSource(hid_device->timerSource);
             hid_device->timerSource->setTimeoutMS(10);
         }
+        
+        if (_wrapper)
+            _wrapper->wakeFromSleep();
         
         IOLog("%s::Woke up from Sleep!\n", getName());
     }

--- a/VoodooI2C/VoodooElanTouchpadDevice.h
+++ b/VoodooI2C/VoodooElanTouchpadDevice.h
@@ -2,9 +2,9 @@
 //  VoodooElanTouchpadDevice.h
 //  VoodooI2C
 //
-//  Created by CoolStar on 12/13/15.
-//  Copyright © 2015 CoolStar. All rights reserved.
-//  ported from crostrackpad-elan 3.0 beta 9.4 for Windows
+//  Created by CoolStar on 6/25/16.
+//  Copyright © 2016 CoolStar. All rights reserved.
+//  ported from crostrackpad-elan 3.0 for Windows
 //
 
 #ifndef VoodooI2C_VoodooElanTouchpadDevice_h
@@ -97,6 +97,8 @@ class VoodooI2CElanTouchpadDevice : public VoodooI2CDevice
     
 private:
     CSGesture* _wrapper;
+    
+    uint32_t hw_res_x, hw_res_y;
     
     void initialize_wrapper(void);
     void destroy_wrapper(void);

--- a/VoodooI2C/VoodooElanTouchpadDevice.h
+++ b/VoodooI2C/VoodooElanTouchpadDevice.h
@@ -105,9 +105,9 @@ protected:
     VoodooI2C* _controller;
     
 public:
-    virtual bool attach(IOService * provider, IOService* child);
-    virtual void detach(IOService * provider);
-    void stop(IOService* device);
+    virtual bool attach(IOService * provider, IOService* child) override;
+    virtual void detach(IOService * provider) override;
+    void stop(IOService* device) override;
     
     
     typedef struct {
@@ -162,7 +162,7 @@ public:
     
     void get_input(OSObject* owner, IOTimerEventSource* sender);
     
-    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice);
+    IOReturn setPowerState(unsigned long powerState, IOService *whatDevice) override;
     
     int i2c_get_slave_address(I2CDevice* hid_device);
     

--- a/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
+++ b/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
@@ -394,7 +394,6 @@ int VoodooI2CAtmelMxtScreenDevice::mxt_read_t100_config()
 
 int VoodooI2CAtmelMxtScreenDevice::initHIDDevice(I2CDevice *hid_device) {
     int ret;
-    UInt16 hidRegister;
     
     int blksize;
     uint32_t crc;

--- a/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.h
+++ b/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.h
@@ -45,9 +45,9 @@ protected:
     VoodooI2C* _controller;
     
 public:
-    virtual bool attach(IOService * provider, IOService* child);
-    virtual void detach(IOService * provider);
-    void stop(IOService* device);
+    virtual bool attach(IOService * provider, IOService* child) override;
+    virtual void detach(IOService * provider) override;
+    void stop(IOService* device) override;
     
     
     typedef struct {

--- a/VoodooI2C/csgesture-softc.h
+++ b/VoodooI2C/csgesture-softc.h
@@ -1,0 +1,77 @@
+// CSGesture Multitouch Touchpad Library
+// © 2016, CoolStar. All Rights Reserved.
+
+#ifndef csgesture_softc_h
+#define csgesture_softc_h
+
+struct csgesture_softc {
+    //hardware input
+    int x[15];
+    int y[15];
+    int p[15];
+    
+    bool buttondown;
+    
+    //hardware info
+    bool infoSetup;
+    
+    char product_id[16];
+    char firmware_version[4];
+    
+    int resx;
+    int resy;
+    int phyx;
+    int phyy;
+    
+    //system output
+    int dx;
+    int dy;
+    
+    int scrollx;
+    int scrolly;
+    
+    int buttonmask;
+    
+    //used internally in driver
+    int panningActive;
+    int idForPanning;
+    
+    int scrollingActive;
+    int idsForScrolling[2];
+    int ticksSinceScrolling;
+    
+    int scrollInertiaActive;
+    
+    int blacklistedids[15];
+    
+    bool mouseDownDueToTap;
+    int idForMouseDown;
+    bool mousedown;
+    int mousebutton;
+    
+    int lastx[15];
+    int lasty[15];
+    int lastp[15];
+    
+    int xhistory[15][10];
+    int yhistory[15][10];
+    
+    int flextotalx[15];
+    int flextotaly[15];
+    
+    int totalx[15];
+    int totaly[15];
+    int totalp[15];
+    
+    int multitaskingx;
+    int multitaskingy;
+    int multitaskinggesturetick;
+    bool multitaskingdone;
+    
+    int tick[15];
+    int truetick[15];
+    int ticksincelastrelease;
+    int tickssinceclick;
+};
+
+#endif /* csgesture_softc_h */

--- a/VoodooI2C/csgesture-softc.h
+++ b/VoodooI2C/csgesture-softc.h
@@ -4,7 +4,16 @@
 #ifndef csgesture_softc_h
 #define csgesture_softc_h
 
+struct csgesture_settings { //note not all settings were brought over from Windows as we are using Apple's settings panel
+    //tap settings
+    bool tapToClickEnabled;
+    bool multiFingerTap;
+    bool tapDragEnabled;
+};
+
 struct csgesture_softc {
+    struct csgesture_settings settings;
+    
     //hardware input
     int x[15];
     int y[15];

--- a/VoodooI2C/csgesture.cpp
+++ b/VoodooI2C/csgesture.cpp
@@ -644,7 +644,7 @@ void CSGesture::initialize_wrapper(IOService *service) {
     destroy_wrapper();
     
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
-    _wrapper = new VoodooCSGestureMouseWrapper;
+    _wrapper = new VoodooCSGestureHIDWrapper;
     if (_wrapper->init()) {
         IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
         _wrapper->gestureEngine = this;

--- a/VoodooI2C/csgesture.h
+++ b/VoodooI2C/csgesture.h
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <IOKit/IOService.h>
 #include <IOKit/IOLib.h>
-#include "VoodooCSGestureMouseWrapper.h"
+#include "VoodooCSGestureHIDWrapper.h"
 
 #define MAX_FINGERS 15
 
@@ -81,7 +81,7 @@ struct csgesture_softc {
 
 class CSGesture {
 private:
-    VoodooCSGestureMouseWrapper *_wrapper;
+    VoodooCSGestureHIDWrapper *_wrapper;
     
     struct {
         UInt8 x;

--- a/VoodooI2C/csgesture.h
+++ b/VoodooI2C/csgesture.h
@@ -8,6 +8,7 @@
 #include <IOKit/IOService.h>
 #include <IOKit/IOLib.h>
 #include "VoodooCSGestureHIDWrapper.h"
+#include "VoodooCSGestureHIPointingWrapper.h"
 
 #define MAX_FINGERS 15
 
@@ -47,6 +48,8 @@ struct csgesture_softc {
     int idsForScrolling[2];
     int ticksSinceScrolling;
     
+    int scrollInertiaActive;
+    
     int blacklistedids[15];
     
     bool mouseDownDueToTap;
@@ -82,6 +85,7 @@ struct csgesture_softc {
 class CSGesture {
 private:
     VoodooCSGestureHIDWrapper *_wrapper;
+    VoodooCSGestureHIPointingWrapper *_pointingWrapper;
     
     struct {
         UInt8 x;

--- a/VoodooI2C/csgesture.h
+++ b/VoodooI2C/csgesture.h
@@ -9,83 +9,16 @@
 #include <IOKit/IOLib.h>
 #include "VoodooCSGestureHIDWrapper.h"
 #include "VoodooCSGestureHIPointingWrapper.h"
+#include "csgesture-softc.h"
+#include "csgesturescroll.h"
 
 #define MAX_FINGERS 15
-
-struct csgesture_softc {
-    //hardware input
-    int x[15];
-    int y[15];
-    int p[15];
-    
-    bool buttondown;
-    
-    //hardware info
-    bool infoSetup;
-    
-    char product_id[16];
-    char firmware_version[4];
-    
-    int resx;
-    int resy;
-    int phyx;
-    int phyy;
-    
-    //system output
-    int dx;
-    int dy;
-    
-    int scrollx;
-    int scrolly;
-    
-    int buttonmask;
-    
-    //used internally in driver
-    int panningActive;
-    int idForPanning;
-    
-    int scrollingActive;
-    int idsForScrolling[2];
-    int ticksSinceScrolling;
-    
-    int scrollInertiaActive;
-    
-    int blacklistedids[15];
-    
-    bool mouseDownDueToTap;
-    int idForMouseDown;
-    bool mousedown;
-    int mousebutton;
-    
-    int lastx[15];
-    int lasty[15];
-    int lastp[15];
-    
-    int xhistory[15][10];
-    int yhistory[15][10];
-    
-    int flextotalx[15];
-    int flextotaly[15];
-    
-    int totalx[15];
-    int totaly[15];
-    int totalp[15];
-    
-    int multitaskingx;
-    int multitaskingy;
-    int multitaskinggesturetick;
-    bool multitaskingdone;
-    
-    int tick[15];
-    int truetick[15];
-    int ticksincelastrelease;
-    int tickssinceclick;
-};
 
 class CSGesture {
 private:
     VoodooCSGestureHIDWrapper *_wrapper;
     VoodooCSGestureHIPointingWrapper *_pointingWrapper;
+    CSGestureScroll *_scrollHandler;
     
     struct {
         UInt8 x;
@@ -100,6 +33,8 @@ private:
                                char x, char y, char wheelPosition, char wheelHPosition);
     void update_keyboard(uint8_t shiftKeys, uint8_t *keyCodes);
 public:
+    csgesture_softc *softc;
+    
     //public csgesture functions
     bool ProcessMove(csgesture_softc *sc, int abovethreshold, int iToUse[3]);
     bool ProcessScroll(csgesture_softc *sc, int abovethreshold, int iToUse[3]);
@@ -110,6 +45,9 @@ public:
     void ProcessGesture(csgesture_softc *sc);
     
     //os specific functions
+    void prepareToSleep();
+    void wakeFromSleep();
+    
     void initialize_wrapper(IOService *service);
     void destroy_wrapper(void);
     

--- a/VoodooI2C/csgesturescroll.cpp
+++ b/VoodooI2C/csgesturescroll.cpp
@@ -1,0 +1,284 @@
+// CSGesture Multitouch Touchpad Library
+// © 2016, CoolStar. All Rights Reserved.
+
+#include "csgesturescroll.h"
+#include <stdint.h>
+#include "VoodooCSGestureHIPointingWrapper.h"
+#include <IOKit/IOTimerEventSource.h>
+
+OSDefineMetaClassAndStructors(CSGestureScroll, IOService);
+
+#ifndef ABS32
+#define ABS32
+inline int32_t abs(int32_t num){
+    if (num < 0){
+        return num * -1;
+    }
+    return num;
+}
+#endif
+
+inline bool isSameSign(int n1, int n2) {
+    if (n1 == 0 || n2 == 0)
+        return true;
+    if (n1 > 0 && n2 > 0)
+        return true;
+    if (n1 < 0 && n2 < 0)
+        return true;
+    return false;
+}
+
+inline bool isPropertyValid(int prop) {
+    if (prop == 65535)
+        return false;
+    return true;
+}
+
+void CSGestureScroll::disableScrollDelayed(){
+    if (!cancelDelayScroll){
+        softc->scrollInertiaActive = false;
+        cancelDelayScroll = false;
+    }
+    
+    if (_disableScrollDelayTimer){
+        _disableScrollDelayTimer->cancelTimeout();
+        _disableScrollDelayTimer->release();
+        _disableScrollDelayTimer = NULL;
+    }
+}
+
+void CSGestureScroll::disableScrollingDelayLaunch(){
+    if (softc->scrollInertiaActive)
+        return;
+    
+    cancelDelayScroll = false;
+    _disableScrollDelayTimer = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &CSGestureScroll::disableScrollDelayed));
+    _workLoop->addEventSource(_disableScrollDelayTimer);
+    _disableScrollDelayTimer->setTimeoutMS(300);
+}
+
+void CSGestureScroll::stopScroll(){
+    momentumscrollcurrentx = 0;
+    momentumscrollrest1x = 0;
+    momentumscrollrest2x = 0;
+    dx_history.reset();
+    
+    momentumscrollcurrenty = 0;
+    momentumscrollrest1y = 0;
+    momentumscrollrest2y = 0;
+    dy_history.reset();
+    isTouchActive = false;
+    
+    disableScrollingDelayLaunch();
+}
+
+void CSGestureScroll::scrollTimer(){
+    if (momentumscrollcurrentx) {
+        int dx = momentumscrollcurrentx / 10 + momentumscrollrest2x;
+        
+        if (abs(dx) > 7) {
+            //dispatch the scroll event
+            if (inertiaScroll) {
+                _pointingWrapper->updateScroll(0, (dx / 7), 0);
+            }
+            
+            momentumscrollrest2x = dx % 1;
+            
+            momentumscrollcurrentx = momentumscrollcurrentx * momentumscrollmultiplierx + momentumscrollrest1x;
+            momentumscrollrest1x = momentumscrollcurrentx % momentumscrolldivisorx;
+            momentumscrollcurrentx /= momentumscrolldivisorx;
+        }
+        else {
+            momentumscrollcurrentx = 0;
+        }
+    }
+    
+    if (momentumscrollcurrenty) {
+        int dy = momentumscrollcurrenty / 10 + momentumscrollrest2y;
+        
+        if (abs(dy) > 7) {
+            //dispatch the scroll event
+            if (inertiaScroll) {
+                _pointingWrapper->updateScroll((dy / 7), 0, 0);
+            }
+            
+            momentumscrollrest2y = dy % 1;
+            
+            momentumscrollcurrenty = momentumscrollcurrenty * momentumscrollmultipliery + momentumscrollrest1y;
+            momentumscrollrest1y = momentumscrollcurrenty % momentumscrolldivisory;
+            momentumscrollcurrenty /= momentumscrolldivisory;
+        }
+        else {
+            momentumscrollcurrenty = 0;
+        }
+    }
+    
+    if (momentumscrollcurrentx == 0 && momentumscrollcurrenty == 0)
+        disableScrollingDelayLaunch();
+    else {
+        cancelDelayScroll = true;
+        softc->scrollInertiaActive = true;
+    }
+    
+    _scrollTimer->setTimeoutMS(10);
+}
+
+void CSGestureScroll::ProcessScroll(int x1, int y1, int x2, int y2) {
+    if (isPropertyValid(x1) &&
+        isPropertyValid(y1) &&
+        isPropertyValid(x2) &&
+        isPropertyValid(y2)){
+        
+        int delta_x1 = x1 - lastx1;
+        int delta_y1 = y1 - lasty1;
+        
+        int delta_x2 = x2 - lastx2;
+        int delta_y2 = y2 - lasty2;
+            
+        lastx1 = x1;
+        lasty1 = y1;
+        lastx2 = x2;
+        lasty2 = y2;
+        
+        int avgy = (delta_y1 + delta_y2) / 2;
+        int avgx = (delta_x1 + delta_x2) / 2;
+        
+        if (abs(avgx) > 100)
+            avgx = 0;
+        if (abs(avgy) > 100)
+            avgx = 0;
+        
+        if (avgx == 0 && avgy == 0) {
+            noScrollCounter++;
+            if (noScrollCounter < 3)
+                return;
+        }
+        else {
+            noScrollCounter = 0;
+        }
+        
+        if (abs(avgy) > abs(avgx)) {
+            _pointingWrapper->updateScroll(avgy, 0, 0);
+            
+            if (!isSameSign(momentumscrollcurrenty, avgy)) {
+                momentumscrollcurrenty = 0;
+                momentumscrollrest1y = 0;
+                momentumscrollrest2y = 0;
+                dy_history.reset();
+            }
+            
+            dy_history.filter(avgy);
+            dx_history.reset();
+        } else {
+            _pointingWrapper->updateScroll(0, avgx, 0);
+            
+            if (!isSameSign(momentumscrollcurrentx, avgx)) {
+                momentumscrollcurrentx = 0;
+                momentumscrollrest1x = 0;
+                momentumscrollrest2x = 0;
+                dx_history.reset();
+            }
+            
+            dx_history.filter(avgx);
+            dy_history.reset();
+        }
+        ;
+        isTouchActive = true;
+    } else {
+        if (isTouchActive){
+            if (dx_history.count() > momentumscrollsamplesmin) {
+                int scrollx = dx_history.sum() * 10;
+                if (isSameSign(momentumscrollcurrentx, scrollx))
+                    momentumscrollcurrentx += scrollx;
+                else
+                    momentumscrollcurrentx = scrollx;
+                momentumscrollrest1x = 0;
+                momentumscrollrest2x = 0;
+            }
+            
+            if (dy_history.count() > momentumscrollsamplesmin) {
+                int scrolly = dy_history.sum() * 10;
+                if (isSameSign(momentumscrollcurrenty, scrolly))
+                    momentumscrollcurrenty += scrolly;
+                else
+                    momentumscrollcurrenty = scrolly;
+                momentumscrollrest1y = 0;
+                momentumscrollrest2y = 0;
+            }
+            
+            dx_history.reset();
+            dy_history.reset();
+            isTouchActive = false;
+        }
+        
+        lastx1 = 0;
+        lasty1 = 0;
+        lastx2 = 0;
+        lasty2 = 0;
+    }
+}
+
+void CSGestureScroll::prepareToSleep(){
+    if (_scrollTimer){
+        _scrollTimer->cancelTimeout();
+        _scrollTimer->release();
+        _scrollTimer = NULL;
+    }
+    
+    if (_disableScrollDelayTimer){
+        _disableScrollDelayTimer->cancelTimeout();
+        _disableScrollDelayTimer->release();
+        _disableScrollDelayTimer = NULL;
+    }
+}
+
+void CSGestureScroll::wakeFromSleep(){
+    if (_scrollTimer){
+        _scrollTimer->cancelTimeout();
+        _scrollTimer->release();
+        _scrollTimer = NULL;
+    }
+    
+    _scrollTimer = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &CSGestureScroll::scrollTimer));
+    _workLoop->addEventSource(_scrollTimer);
+    _scrollTimer->setTimeoutMS(10);
+}
+
+bool CSGestureScroll::start(IOService *provider){
+    if (!super::start(provider))
+        return false;
+    
+    _workLoop = getWorkLoop();
+    if (!_workLoop){
+        IOLog("CSGestureScroll: Failed to get workloop!\n");
+        return false;
+    }
+    
+    _workLoop->retain();
+    
+    _scrollTimer = IOTimerEventSource::timerEventSource(this, OSMemberFunctionCast(IOTimerEventSource::Action, this, &CSGestureScroll::scrollTimer));
+    _workLoop->addEventSource(_scrollTimer);
+    _scrollTimer->setTimeoutMS(10);
+    if (_scrollTimer)
+        return true;
+    return false;
+}
+
+void CSGestureScroll::stop(){
+    if (_scrollTimer){
+        _scrollTimer->cancelTimeout();
+        _scrollTimer->release();
+        _scrollTimer = NULL;
+    }
+    
+    if (_disableScrollDelayTimer){
+        _disableScrollDelayTimer->cancelTimeout();
+        _disableScrollDelayTimer->release();
+        _disableScrollDelayTimer = NULL;
+    }
+    
+    if (_workLoop) {
+        _workLoop->release();
+        _workLoop = NULL;
+    }
+}

--- a/VoodooI2C/csgesturescroll.cpp
+++ b/VoodooI2C/csgesturescroll.cpp
@@ -165,6 +165,9 @@ void CSGestureScroll::ProcessScroll(int x1, int y1, int x2, int y2) {
             noScrollCounter = 0;
         }
         
+        avgy = -avgy;
+        avgx = -avgx;
+        
         if (abs(avgy) > abs(avgx)) {
             _pointingWrapper->updateScroll(avgy, 0, 0);
             

--- a/VoodooI2C/csgesturescroll.cpp
+++ b/VoodooI2C/csgesturescroll.cpp
@@ -134,11 +134,19 @@ void CSGestureScroll::ProcessScroll(int x1, int y1, int x2, int y2) {
         
         int delta_x2 = x2 - lastx2;
         int delta_y2 = y2 - lasty2;
+        
+        bool ignoreScroll = false;
+        
+        if (lastx1 == 0 || lasty1 == 0 || lastx2 == 0 || lasty2 == 0)
+            ignoreScroll = true;
             
         lastx1 = x1;
         lasty1 = y1;
         lastx2 = x2;
         lasty2 = y2;
+        
+        if (ignoreScroll)
+            return;
         
         int avgy = (delta_y1 + delta_y2) / 2;
         int avgx = (delta_x1 + delta_x2) / 2;

--- a/VoodooI2C/csgesturescroll.h
+++ b/VoodooI2C/csgesturescroll.h
@@ -1,0 +1,78 @@
+// CSGesture Multitouch Touchpad Library
+// © 2016, CoolStar. All Rights Reserved.
+
+#include <IOKit/IOService.h>
+#include "AverageClasses.h"
+#include "csgesture.h"
+
+#ifndef csgesturescroll_h
+#define csgesturescroll_h
+
+typedef class VoodooCSGestureHIPointingWrapper;
+
+class CSGestureScroll : public IOService {
+    typedef IOService super;
+    OSDeclareDefaultStructors(CSGestureScroll);
+    
+private:
+    SimpleAverage<int, 32> dy_history;
+    SimpleAverage<int, 32> dx_history;
+    
+    int lastx1 = 0;
+    int lasty1 = 0;
+    int lastx2 = 0;
+    int lasty2 = 0;
+    
+    bool isTouchActive = false;
+    
+    int momentumscrollsamplesmin = 3;
+    
+    int momentumscrollcurrentx = 0;
+    int momentumscrollmultiplierx = 98;
+    int momentumscrolldivisorx = 100;
+    int momentumscrollrest1x = 0;
+    int momentumscrollrest2x = 0;
+    
+    int momentumscrollcurrenty = 0;
+    int momentumscrollmultipliery = 98;
+    int momentumscrolldivisory = 100;
+    int momentumscrollrest1y = 0;
+    int momentumscrollrest2y = 0;
+    
+    bool cancelDelayScroll = false;
+    
+    int noScrollCounter = 0;
+    
+    IOTimerEventSource *_disableScrollDelayTimer;
+    
+    IOTimerEventSource *_scrollTimer;
+    
+    IOWorkLoop *_workLoop;
+    
+    void disableScrollDelayed();
+    
+    void disableScrollingDelayLaunch();
+    
+    void scrollTimer();
+    
+public:
+    bool inertiaScroll = true;
+    
+    CSGesture *_gestureEngine;
+    
+    csgesture_softc *softc;
+    
+    VoodooCSGestureHIPointingWrapper *_pointingWrapper;
+    
+    void prepareToSleep();
+    void wakeFromSleep();
+    
+    void stopScroll();
+    
+    bool start(IOService *provider);
+    
+    void stop();
+    
+    void ProcessScroll(int x1, int y1, int x2, int y2);
+};
+#endif /* csgesturescroll_h */

--- a/VoodooI2C/csgesturescroll.h
+++ b/VoodooI2C/csgesturescroll.h
@@ -69,7 +69,7 @@ public:
     
     void stopScroll();
     
-    bool start(IOService *provider);
+    bool start(IOService *provider) override;
     
     void stop();
     


### PR DESCRIPTION
This patch refactors code for all CSGesture based trackpads (currently Cypress and Elan).

Also adds smooth scrolling and inertia scroll (ported from crostrackpadscroll on Windows) to both Cypress and Elan trackpads so scrolling is closer to real Macbooks' scrolling.

Elan trackpads' code has been updated to the latest from crostrackpad3-elan to resolve resolution issues on devices other than the Acer C720 and C740 chromebooks.

This also adds initial support for the trackpad settings pane (currently horizontal scroll, tap to click and tap drag can be toggled via Apple's settings pane, with more to come). The trackpad settings pane is the same one that shows up when VoodooPS2Controller is used on a Synaptics PS2 trackpad.

Finally I cleaned up compiler warnings with CSGesture, Cypress & Elan Trackpads and the Atmel touch screen drivers.