### PR TITLE
Code cleanup; Skylake PCI support; ACPI fallback; more code comments; better error logging; ELAN1000 multitouch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following devices are confirmed to work with the current iteration of Voodoo
   * This uses the proprietary interface `VoodooI2CAtmelMxtScreenDevice`.
 * ELAN0000 trackpad (Broadwell Chromebooks)
  * This uses the proprietary interface `VoodooElanTouchpadDevice`
+* ELAN1000 trackpad (Skylake Asus K501UB-DM039D)
+ * This uses the proprietary interface `VoodooElanTouchpadDevice`
 
 # Helping out and testing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ VoodooI2C is a project to bring support for I2C input devices to OS X. This repo
 Currently the following Intel Lynxpoint I2C controllers are almost fully supported:
 * `INT33C2` and `INT33C3` - Haswell era
 * `INT3432` and `INT3433` - Broadwell era
+* `pci8086,9d60`, `pci8086,9d61`, `pci8086,a160` and `pci8086,a161` - Skylake era
 
 Most i2c-hid touchscreens and trackpads work with minor modifications to the drivers. Note that most device have only very basic mouse functionality (navigating, left/right click, scrolling).
 
@@ -20,6 +21,7 @@ The following devices are confirmed to work with the current iteration of Voodoo
 * Atmel 1000 touchscreen (Dell XPS 12)
 * NTRG 0001 touchscreen (Surface Pro 3)
 * FTSC1000 touchscreen (Cube i7)
+* WCOM4818 touch screen + stylus (Skylake HP Elite X2 1012)
 * CYAP0000 trackpad (Haswell Chromebooks)
  * This uses the proprietary interface `VoodooCyapaGen3Device`.
 * ATML0001 touchscreen (Acer C720P Chromebook/Chromebook Pixel 2)

--- a/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */ = {isa = PBXBuildFile; fileRef = F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */; };
 		F17D8FF81CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F17D8FF61CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp */; };
 		F17D8FF91CBABF15002F9115 /* VoodooAtmelTouchWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F17D8FF71CBABF15002F9115 /* VoodooAtmelTouchWrapper.h */; };
+		F18F3CFB1D88C1C600CCED2B /* VoodooI2CPCI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F18F3CF91D88C1C600CCED2B /* VoodooI2CPCI.cpp */; };
+		F18F3CFC1D88C1C600CCED2B /* VoodooI2CPCI.h in Headers */ = {isa = PBXBuildFile; fileRef = F18F3CFA1D88C1C600CCED2B /* VoodooI2CPCI.h */; };
 		F191539C1D25CE14007972A7 /* csgesture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F191539B1D25CE14007972A7 /* csgesture.cpp */; };
 		F19857311D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */; };
 		F19857321D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F19857301D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.h */; };
@@ -51,6 +53,8 @@
 		F158186B1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooCyapaGen3Device.h; sourceTree = "<group>"; };
 		F17D8FF61CBABF15002F9115 /* VoodooAtmelTouchWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooAtmelTouchWrapper.cpp; sourceTree = "<group>"; };
 		F17D8FF71CBABF15002F9115 /* VoodooAtmelTouchWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooAtmelTouchWrapper.h; sourceTree = "<group>"; };
+		F18F3CF91D88C1C600CCED2B /* VoodooI2CPCI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooI2CPCI.cpp; sourceTree = "<group>"; };
+		F18F3CFA1D88C1C600CCED2B /* VoodooI2CPCI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoodooI2CPCI.h; sourceTree = "<group>"; };
 		F191539B1D25CE14007972A7 /* csgesture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = csgesture.cpp; sourceTree = "<group>"; };
 		F1937E791D1F455700F97772 /* csgesture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = csgesture.h; sourceTree = "<group>"; };
 		F198572F1D7F80AE00BAB4BB /* VoodooCSGestureHIPointingWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooCSGestureHIPointingWrapper.cpp; sourceTree = "<group>"; };
@@ -97,6 +101,8 @@
 			children = (
 				AC45AFEC1A32543B008E6857 /* VoodooI2C.h */,
 				AC45AFEE1A32543B008E6857 /* VoodooI2C.cpp */,
+				F18F3CF91D88C1C600CCED2B /* VoodooI2CPCI.cpp */,
+				F18F3CFA1D88C1C600CCED2B /* VoodooI2CPCI.h */,
 				AC45AFEA1A32543B008E6857 /* Supporting Files */,
 				F19963071CAD6EE3002E2D29 /* VoodooI2CDevice.cpp */,
 				F19963081CAD6EE3002E2D29 /* VoodooI2CDevice.h */,
@@ -180,6 +186,7 @@
 				F158186D1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.h in Headers */,
 				F153120B1CB96C8300BE6BFC /* VoodooI2CAtmelMxtScreenDevice.h in Headers */,
 				AC45AFED1A32543B008E6857 /* VoodooI2C.h in Headers */,
+				F18F3CFC1D88C1C600CCED2B /* VoodooI2CPCI.h in Headers */,
 				F199630A1CAD6EE3002E2D29 /* VoodooI2CDevice.h in Headers */,
 				F1FA896C1D7FAAC90019F9CF /* AverageClasses.h in Headers */,
 				F17D8FF91CBABF15002F9115 /* VoodooAtmelTouchWrapper.h in Headers */,
@@ -268,6 +275,7 @@
 				F110CDBA1D1F3B4D0057BBDB /* VoodooElanTouchpadDevice.cpp in Sources */,
 				F19963091CAD6EE3002E2D29 /* VoodooI2CDevice.cpp in Sources */,
 				F158186C1C1D6B8F0086ED55 /* VoodooCyapaGen3Device.cpp in Sources */,
+				F18F3CFB1D88C1C600CCED2B /* VoodooI2CPCI.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -30,6 +30,10 @@
 			<string>VoodooI2C</string>
 			<key>IONameMatch</key>
 			<array>
+				<string>pci8086,9d60</string>
+				<string>pci8086,9d61</string>
+				<string>pci8086,a160</string>
+				<string>pci8086,a161</string>
 				<string>INT33C2</string>
 				<string>INT33C3</string>
 				<string>INT3432</string>

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -40,7 +40,9 @@
 				<string>INT3433</string>
 			</array>
 			<key>IOProviderClass</key>
-			<string>IOACPIPlatformDevice</string>
+			<string>IOService</string>
+			<key>IOProbeScore</key>
+			<string>5000</string>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -45,6 +45,8 @@
 	<dict>
 		<key>com.apple.iokit.IOACPIFamily</key>
 		<string>1.4</string>
+		<key>com.apple.iokit.IOPCIFamily</key>
+		<string>2.0</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>

--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -42,7 +42,7 @@
 			<key>IOProviderClass</key>
 			<string>IOService</string>
 			<key>IOProbeScore</key>
-			<string>5000</string>
+			<integer>5000</integer>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/VoodooI2C/VoodooElanTouchpadDevice.h
+++ b/VoodooI2C/VoodooElanTouchpadDevice.h
@@ -174,7 +174,6 @@ public:
     SInt32 readI2C(uint8_t reg, size_t len, uint8_t *values);
     SInt32 readI2C16(uint16_t reg, size_t len, uint8_t *values);
     SInt32 writeI2C(uint8_t reg, size_t len, uint8_t *values);
-    SInt32 writeI2C16(uint16_t reg, size_t len, uint8_t *values);
     void TrackpadRawInput(struct csgesture_softc *sc, uint8_t report[ETP_MAX_REPORT_LEN], int tickinc);
 };
 

--- a/VoodooI2C/VoodooI2C.cpp
+++ b/VoodooI2C/VoodooI2C.cpp
@@ -141,6 +141,9 @@ UInt32 VoodooI2C::funcI2C(I2CBus* _dev) {
  */
 
 bool VoodooI2C::getACPIParams(IOACPIPlatformDevice* fACPIDevice, char* method, UInt32 *hcnt, UInt32 *lcnt, UInt32 *sda_hold) {
+    if (!fACPIDevice)
+        return false;
+    
     OSObject *object;
     IOReturn status = fACPIDevice->evaluateObject(method, &object);
     

--- a/VoodooI2C/VoodooI2C.cpp
+++ b/VoodooI2C/VoodooI2C.cpp
@@ -67,7 +67,7 @@ bool VoodooI2C::acpiConfigure(I2CBus* _dev) {
 }
 
 bool VoodooI2C::fallbackConfigure(I2CBus *_dev){
-    IOLog("Loading hardcoded settings for HSW/BDW/SKL\n");
+    IOLog("%s::%s:: Loading hardcoded settings for HSW/BDW/SKL\n", getName(), _dev->name);
     _dev->tx_fifo_depth = 32;
     _dev->rx_fifo_depth = 32;
     

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -266,6 +266,7 @@ public:
     
     static bool getACPIParams(IOACPIPlatformDevice* fACPIDevice, char method[], UInt32 *hcnt, UInt32 *lcnt, UInt32 *sda_hold);
     bool acpiConfigure(I2CBus* _dev);
+    bool fallbackConfigure(I2CBus *_dev);
     void disableI2CInt(I2CBus* _dev);
     void enableI2CDevice(I2CBus*, bool enabled);
     UInt32 funcI2C(I2CBus* _dev);

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -156,15 +156,12 @@
 #define I2C_HID_PWR_ON 0x00
 #define I2C_HID_PWR_SLEEP 0x01
 
-
 class VoodooI2C : public IOService {
     
     OSDeclareDefaultStructors(VoodooI2C);
     
     
 public:
-    IOACPIPlatformDevice* fACPIDevice;
-    
     struct i2c_msg {
         UInt16 addr;
         UInt16 flags;
@@ -191,7 +188,7 @@ public:
     } i2c_smbus_data;
     
     typedef struct {
-        IOACPIPlatformDevice *provider;
+        IOService *provider;
         
         IOWorkLoop *workLoop;
         IOInterruptEventSource *interruptSource;

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -156,6 +156,11 @@
 #define I2C_HID_PWR_ON 0x00
 #define I2C_HID_PWR_SLEEP 0x01
 
+enum VoodooI2CDeviceMode {
+    VoodooI2CDeviceModeACPI,
+    VoodooI2CDeviceModePCI
+};
+
 class VoodooI2C : public IOService {
     
     OSDeclareDefaultStructors(VoodooI2C);
@@ -189,6 +194,8 @@ public:
     
     typedef struct {
         IOService *provider;
+        
+        VoodooI2CDeviceMode deviceMode;
         
         IOWorkLoop *workLoop;
         IOInterruptEventSource *interruptSource;

--- a/VoodooI2C/VoodooI2C.h
+++ b/VoodooI2C/VoodooI2C.h
@@ -264,7 +264,7 @@ public:
 
     
     
-    static void getACPIParams(IOACPIPlatformDevice* fACPIDevice, char method[], UInt32 *hcnt, UInt32 *lcnt, UInt32 *sda_hold);
+    static bool getACPIParams(IOACPIPlatformDevice* fACPIDevice, char method[], UInt32 *hcnt, UInt32 *lcnt, UInt32 *sda_hold);
     bool acpiConfigure(I2CBus* _dev);
     void disableI2CInt(I2CBus* _dev);
     void enableI2CDevice(I2CBus*, bool enabled);

--- a/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
+++ b/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
@@ -49,9 +49,7 @@ inline int32_t abs(int32_t num){
 0x81, 0x02,                         /*       INPUT (Data,Var,Abs)       */ \
 0x09, 0x32,                         /*       USAGE (In Range)           */ \
 0x81, 0x02,                         /*       INPUT (Data,Var,Abs)       */ \
-0x09, 0x47,                         /*       USAGE (Confidence)         */ \
-0x81, 0x02,                         /*       INPUT (Data,Var,Abs)       */ \
-0x95, 0x05,                         /*       REPORT_COUNT (5)           */ \
+0x95, 0x06,                         /*       REPORT_COUNT (6)           */ \
 0x81, 0x03,                         /*       INPUT (Cnst,Ary,Abs)       */ \
 0x75, 0x08,                         /*       REPORT_SIZE (8)            */ \
 0x09, 0x51,                         /*       USAGE (Contact Identifier) */ \
@@ -798,10 +796,10 @@ int VoodooI2CAtmelMxtScreenDevice::ProcessMessage(uint8_t *message) {
             
             uint8_t flags = Flags[i];
             if (flags & MXT_T9_DETECT) {
-                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_CONFIDENCE_BIT | MULTI_TIPSWITCH_BIT;
+                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_TIPSWITCH_BIT;
             }
             else if (flags & MXT_T9_PRESS) {
-                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_CONFIDENCE_BIT | MULTI_TIPSWITCH_BIT;
+                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_TIPSWITCH_BIT;
             }
             else if (flags & MXT_T9_RELEASE) {
                 report.Touch[count].Status = 0;
@@ -979,10 +977,10 @@ void VoodooI2CAtmelMxtScreenDevice::write_report_to_buffer(IOMemoryDescriptor *b
             
             uint8_t flags = Flags[i];
             if (flags & MXT_T9_DETECT) {
-                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_CONFIDENCE_BIT | MULTI_TIPSWITCH_BIT;
+                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_TIPSWITCH_BIT;
             }
             else if (flags & MXT_T9_PRESS) {
-                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_CONFIDENCE_BIT | MULTI_TIPSWITCH_BIT;
+                report.Touch[count].Status = MULTI_IN_RANGE_BIT | MULTI_TIPSWITCH_BIT;
             }
             else if (flags & MXT_T9_RELEASE) {
                 report.Touch[count].Status = 0;

--- a/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.h
+++ b/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.h
@@ -150,6 +150,10 @@ public:
     uint8_t T100_reportid_min;
     uint8_t T100_reportid_max;
     
+    uint8_t max_reportid;
+    
+    uint8_t last_message_count;
+    
     uint32_t TouchCount;
     
     uint8_t      Flags[20];
@@ -173,6 +177,12 @@ public:
     void atmel_reset_device();
     int mxt_read_t9_resolution();
     int mxt_read_t100_config();
+    
+    int ProcessMessagesUntilInvalid();
+    int ProcessMessage(uint8_t *message);
+    int ReadAndProcessMessages(uint8_t count);
+    bool DeviceReadT44();
+    bool DeviceRead();
     
     SInt32 readI2C(uint8_t reg, size_t len, uint8_t *values);
     SInt32 writeI2C(uint8_t reg, size_t len, uint8_t *values);

--- a/VoodooI2C/VoodooI2CPCI.cpp
+++ b/VoodooI2C/VoodooI2CPCI.cpp
@@ -1,0 +1,73 @@
+//
+//  VoodooI2CPCI.cpp
+//  VoodooI2C
+//
+//  Created by Maxime Vincent on 25/06/16.
+//  Copyright © 2016 Maxime Vincent. All rights reserved.
+//
+
+#include "VoodooI2CPCI.h"
+
+#define super    IOService
+OSDefineMetaClassAndStructors(VoodooI2CPCI, IOService);
+
+bool VoodooI2CPCI::init(IOService* provider)
+{
+    if (!super::init()) {
+        // Perform any required clean-up, then return.
+        return false;
+    }
+    return true;
+}
+
+void VoodooI2CPCI::free(void)
+{
+    //deviceRegisterMap->release();
+    super::free();
+    return;
+}
+
+
+void VoodooI2CPCI::pciConfigure(IOPCIDevice* fPCIDevice)
+{
+    IOLog("Set PCI Power State D0\n");
+    fPCIDevice->enablePCIPowerManagement(kPCIPMCSPowerStateD0);
+    
+    /*
+     * Enable PCI device / memory response from the card
+     */
+    fPCIDevice->setBusMasterEnable(true);
+    fPCIDevice->setMemoryEnable(true);
+}
+
+IOACPIPlatformDevice* VoodooI2CPCI::getACPIDevice(IORegistryEntry * device)
+{
+    IOACPIPlatformDevice *  acpiDevice = 0;
+    OSString *				acpiPath;
+    
+    if (device)
+    {
+        acpiPath = (OSString *) device->copyProperty(kACPIDevicePathKey);
+        if (acpiPath && !OSDynamicCast(OSString, acpiPath))
+        {
+            acpiPath->release();
+            acpiPath = 0;
+        }
+        
+        if (acpiPath)
+        {
+            IORegistryEntry * entry;
+            
+            // fromPath returns a retain()'d entry that needs to be released later
+            entry = IORegistryEntry::fromPath(acpiPath->getCStringNoCopy());
+            acpiPath->release();
+            
+            if (entry && entry->metaCast("IOACPIPlatformDevice"))
+                acpiDevice = (IOACPIPlatformDevice *) entry;
+            else if (entry)
+                entry->release();
+        }
+    }
+    
+    return (acpiDevice);
+}

--- a/VoodooI2C/VoodooI2CPCI.h
+++ b/VoodooI2C/VoodooI2CPCI.h
@@ -1,0 +1,33 @@
+//
+//  VoodooI2CPCI.h
+//  VoodooI2CPCI
+//
+//  Created by Maxime Vincent on 25/06/16.
+//  Copyright © 2016 Alexandre Daoud. All rights reserved.
+//
+
+#ifndef VoodooI2CPCI_hpp
+#define VoodooI2CPCI_hpp
+
+
+#include <IOKit/pci/IOPCIDevice.h>
+#include <IOKit/acpi/IOACPIPlatformDevice.h>
+
+
+#ifndef kACPIDevicePathKey
+#define kACPIDevicePathKey			"acpi-path"
+#endif
+
+
+class VoodooI2CPCI : public IOService {
+    OSDeclareDefaultStructors(VoodooI2CPCI);
+    
+public:
+    bool                            init(IOService* provider);
+    void                            free(void);
+    static void             pciConfigure(IOPCIDevice* fPCIDevice);
+    static IOACPIPlatformDevice*    getACPIDevice(IORegistryEntry * device);
+};
+
+
+#endif /* VoodooI2CPCIDevice_hpp */

--- a/VoodooI2C/atmel_mxt.h
+++ b/VoodooI2C/atmel_mxt.h
@@ -130,6 +130,8 @@ typedef struct __attribute__((__packed__)){
 #define MXT_SPT_CTECONFIG_T46		46
 #define MXT_TOUCH_MULTITOUCHSCREEN_T100 100
 
+#define MXT_OBJECT_START	0x07
+
 /*
  * register 0 - Object configuration element(s) (occurs after mxt_id_info)
  */
@@ -167,6 +169,14 @@ typedef struct __attribute__((__packed__)){
     uint8_t area;
     uint8_t amplitude;
 } mxt_message_touch_t9;
+
+/* Define for T6 status byte */
+#define MXT_T6_STATUS_RESET	(1 << 7)
+#define MXT_T6_STATUS_OFL	(1 << 6)
+#define MXT_T6_STATUS_SIGERR	(1 << 5)
+#define MXT_T6_STATUS_CAL	(1 << 4)
+#define MXT_T6_STATUS_CFGERR	(1 << 3)
+#define MXT_T6_STATUS_COMSERR	(1 << 2)
 
 /* MXT_TOUCH_MULTI_T9 field */
 #define MXT_T9_CTRL		0
@@ -577,6 +587,11 @@ MXT_RESERVED255		}
 #define MXT_CMDPROC_REPORTALL_OFF	0x03
 #define MXT_CMDPROC_RESERVED04_OFF	0x04
 #define MXT_CMDPROC_DIAGNOSTIC_OFF	0x05
+
+/* Define for MXT_GEN_COMMAND_T6 */
+#define MXT_BOOT_VALUE		0xa5
+#define MXT_RESET_VALUE		0x01
+#define MXT_BACKUP_VALUE	0x55
 
 /*
  * device driver helper structures

--- a/VoodooI2C/csgesture.cpp
+++ b/VoodooI2C/csgesture.cpp
@@ -37,90 +37,6 @@ typedef unsigned char BYTE;
 
 unsigned char csgesturedesc[] = {
     //
-    // Relative mouse report starts here
-    //
-    0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
-    0x09, 0x02,                         // USAGE (Mouse)
-    0xa1, 0x01,                         // COLLECTION (Application)
-    0x85, REPORTID_RELATIVE_MOUSE,      //   REPORT_ID (Mouse)
-    0x09, 0x01,                         //   USAGE (Pointer)
-    0xa1, 0x00,                         //   COLLECTION (Physical)
-    0x05, 0x09,                         //     USAGE_PAGE (Button)
-    0x19, 0x01,                         //     USAGE_MINIMUM (Button 1)
-    0x29, 0x05,                         //     USAGE_MAXIMUM (Button 5)
-    0x15, 0x00,                         //     LOGICAL_MINIMUM (0)
-    0x25, 0x01,                         //     LOGICAL_MAXIMUM (1)
-    0x75, 0x01,                         //     REPORT_SIZE (1)
-    0x95, 0x05,                         //     REPORT_COUNT (5)
-    0x81, 0x02,                         //     INPUT (Data,Var,Abs)
-    0x95, 0x03,                         //     REPORT_COUNT (3)
-    0x81, 0x03,                         //     INPUT (Cnst,Var,Abs)
-    0x05, 0x01,                         //     USAGE_PAGE (Generic Desktop)
-    0x09, 0x30,                         //     USAGE (X)
-    0x09, 0x31,                         //     USAGE (Y)
-    0x15, 0x81,                         //     Logical Minimum (-127)
-    0x25, 0x7F,                         //     Logical Maximum (127)
-    0x75, 0x08,                         //     REPORT_SIZE (8)
-    0x95, 0x02,                         //     REPORT_COUNT (2)
-    0x81, 0x06,                         //     INPUT (Data,Var,Rel)
-    0x05, 0x01,                         //     Usage Page (Generic Desktop)
-    0x09, 0x38,                         //     Usage (Wheel)
-    0x15, 0x81,                         //     Logical Minimum (-127)
-    0x25, 0x7F,                         //     Logical Maximum (127)
-    0x75, 0x08,                         //     Report Size (8)
-    0x95, 0x01,                         //     Report Count (1)
-    0x81, 0x06,                         //     Input (Data, Variable, Relative)
-    // ------------------------------  Horizontal wheel
-    0x05, 0x0c,                         //     USAGE_PAGE (Consumer Devices)
-    0x0a, 0x38, 0x02,                   //     USAGE (AC Pan)
-    0x15, 0x81,                         //     LOGICAL_MINIMUM (-127)
-    0x25, 0x7f,                         //     LOGICAL_MAXIMUM (127)
-    0x75, 0x08,                         //     REPORT_SIZE (8)
-    0x95, 0x01,                         //     Report Count (1)
-    0x81, 0x06,                         //     Input (Data, Variable, Relative)
-    0xc0,                               //   END_COLLECTION
-    0xc0,                               // END_COLLECTION
-    
-    /*//TOUCH PAD input TLC
-     0x05, 0x0d,                         // USAGE_PAGE (Digitizers)
-     0x09, 0x05,                         // USAGE (Touch Pad)
-     0xa1, 0x01,                         // COLLECTION (Application)
-     0x85, REPORTID_TOUCHPAD,            //   REPORT_ID (Touch pad)
-     0x09, 0x22,                         //   USAGE (Finger)
-     0xa1, 0x02,                         //   COLLECTION (Logical)
-     0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
-     0x25, 0x01,                         //       LOGICAL_MAXIMUM (1)
-     0x09, 0x47,                         //       USAGE (Confidence)
-     0x09, 0x42,                         //       USAGE (Tip switch)
-     0x95, 0x02,                         //       REPORT_COUNT (2)
-     0x75, 0x01,                         //       REPORT_SIZE (1)
-     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-     0x95, 0x01,                         //       REPORT_COUNT (1)
-     0x75, 0x02,                         //       REPORT_SIZE (2)
-     0x25, 0x02,                         //       LOGICAL_MAXIMUM (2)
-     0x09, 0x51,                         //       USAGE (Contact Identifier)
-     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-     0x75, 0x01,                         //       REPORT_SIZE (1)
-     0x95, 0x04,                         //       REPORT_COUNT (4)
-     0x81, 0x03,                         //       INPUT (Cnst,Var,Abs)
-     0x05, 0x01,                         //       USAGE_PAGE (Generic Desk..
-     0x15, 0x00,                         //       LOGICAL_MINIMUM (0)
-     0x26, 0xff, 0x0f,                   //       LOGICAL_MAXIMUM (4095)
-     0x75, 0x10,                         //       REPORT_SIZE (16)
-     0x55, 0x0e,                         //       UNIT_EXPONENT (-2)
-     0x65, 0x13,                         //       UNIT(Inch,EngLinear)
-     0x09, 0x30,                         //       USAGE (X)
-     0x35, 0x00,                         //       PHYSICAL_MINIMUM (0)
-     0x46, 0x90, 0x01,                   //       PHYSICAL_MAXIMUM (400)
-     0x95, 0x01,                         //       REPORT_COUNT (1)
-     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-     0x46, 0x13, 0x01,                   //       PHYSICAL_MAXIMUM (275)
-     0x09, 0x31,                         //       USAGE (Y)
-     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
-     0xc0,                               //    END_COLLECTION
-     0xc0,                               // END_COLLECTION*/
-    
-    //
     // Keyboard report starts here
     //
     0x05, 0x01,                         // USAGE_PAGE (Generic Desktop)
@@ -246,7 +162,7 @@ bool CSGesture::ProcessScroll(csgesture_softc *sc, int abovethreshold, int iToUs
         int i2 = iToUse[1];
         
         if (!sc->scrollingActive && !sc->scrollInertiaActive) {
-            if (sc->truetick[i1] < 4 && sc->truetick[i2] < 4)
+            if (sc->truetick[i1] < 8 && sc->truetick[i2] < 8)
                 return false;
         }
         
@@ -265,13 +181,13 @@ bool CSGesture::ProcessScroll(csgesture_softc *sc, int abovethreshold, int iToUs
             }
         }
         
-#if 0
         int delta_x1 = sc->x[i1] - sc->lastx[i1];
         int delta_y1 = sc->y[i1] - sc->lasty[i1];
         
         int delta_x2 = sc->x[i2] - sc->lastx[i2];
         int delta_y2 = sc->y[i2] - sc->lasty[i2];
         
+#if 0
         if ((abs(delta_y1) + abs(delta_y2)) > (abs(delta_x1) + abs(delta_x2))) {
             int avgy = (delta_y1 + delta_y2) / 2;
             sc->scrolly = avgy;
@@ -314,6 +230,21 @@ bool CSGesture::ProcessScroll(csgesture_softc *sc, int abovethreshold, int iToUs
         sc->scrollx = -sc->scrollx;
         sc->scrolly = -sc->scrolly;
 #endif
+        
+        int scrollx = 0;
+        int scrolly = 0;
+        
+        if ((abs(delta_y1) + abs(delta_y2)) > (abs(delta_x1) + abs(delta_x2))) {
+            int avgy = (delta_y1 + delta_y2) / 2;
+            scrolly = avgy;
+        }
+        else {
+            int avgx = (delta_x1 + delta_x2) / 2;
+            scrollx = avgx;
+        }
+        
+        if (abs(scrollx) < 5 && abs(scrolly) < 5 && !sc->scrollingActive)
+            return false;
 
         _scrollHandler->softc = sc;
         _scrollHandler->ProcessScroll(filterNegative(sc->x[i1]),
@@ -448,12 +379,18 @@ void CSGesture::TapToClickOrDrag(csgesture_softc *sc, int button) {
         sc->tickssinceclick = 0;
         return;
     }
-    if (button == 0)
-        return;
     
     for (int i = 0; i < MAX_FINGERS; i++){
         if (sc->truetick[i] < 10 && sc->truetick[i] > 0)
             button++;
+    }
+    
+    if (button == 0)
+        return;
+    
+    if (_scrollHandler->isScrolling()){
+        _scrollHandler->stopScroll();
+        return;
     }
     
     int buttonmask = 0;
@@ -534,10 +471,12 @@ void CSGesture::ProcessGesture(csgesture_softc *sc) {
     
 #pragma mark process different gestures
     bool handled = false;
+    bool handledByScroll = false;
+    
     if (!handled)
         handled = ProcessThreeFingerSwipe(sc, abovethreshold, iToUse);
     if (!handled)
-        handled = ProcessScroll(sc, abovethreshold, iToUse);
+        handledByScroll = handled = ProcessScroll(sc, abovethreshold, iToUse);
     if (!handled)
         handled = ProcessMove(sc, abovethreshold, iToUse);
     
@@ -666,7 +605,8 @@ void CSGesture::ProcessGesture(csgesture_softc *sc) {
     sc->ticksincelastrelease++;
     
 #pragma mark process tap to click
-    TapToClickOrDrag(sc, releasedfingers);
+    if (!handledByScroll)
+        TapToClickOrDrag(sc, releasedfingers);
     
 #pragma mark send to system
     update_relative_mouse(sc->buttonmask, sc->dx, sc->dy, sc->scrolly, sc->scrollx);

--- a/VoodooI2C/csgesturescroll.cpp
+++ b/VoodooI2C/csgesturescroll.cpp
@@ -57,6 +57,19 @@ void CSGestureScroll::disableScrollingDelayLaunch(){
     _disableScrollDelayTimer->setTimeoutMS(300);
 }
 
+bool CSGestureScroll::isScrolling(){
+    if (isTouchActive)
+        return true;
+    
+    if (momentumscrollcurrenty > 0 || momentumscrollrest1y > 0 || momentumscrollrest2y > 0)
+        return true;
+    
+    if (momentumscrollcurrentx > 0 || momentumscrollrest1x > 0 || momentumscrollrest2x > 0)
+        return true;
+    
+    return false;
+}
+
 void CSGestureScroll::stopScroll(){
     momentumscrollcurrentx = 0;
     momentumscrollrest1x = 0;

--- a/VoodooI2C/csgesturescroll.h
+++ b/VoodooI2C/csgesturescroll.h
@@ -67,6 +67,8 @@ public:
     void prepareToSleep();
     void wakeFromSleep();
     
+    bool isScrolling();
+    
     void stopScroll();
     
     bool start(IOService *provider) override;


### PR DESCRIPTION
I have made several cleanups to the I2C bus code on platforms that use ACPI (Haswell/Broadwell) so that we only need to keep 1 reference to the IOService provider around, casting in the few places we need IOACPIPlatform for the ACPI calls. The ACPI config calls now properly return false if there's a problem querying ACPI, and a fallback method is used if the ACPI calls fail to set hardcoded known values for haswell/broadwell.

For Skylake support, I have cleaned up and imported code from maximevince's repo, making minimal changes to VoodooI2C.cpp (sharing as much common codebase as we can between ACPI and PCI, and for the minimal PCI specific code, it is in the separate VoodooI2CPCI.cpp) file. As for the Skylake hack, I have added an enum that describes whether the i2c bus is running in ACPI or PCI mode and only applies the skylake hack if it's in PCI mode. Some adjustments to Info.plist were needed to add the Skylake PCI ID's and to allow the kext to load with both PCI and ACPI configurations.

I have then brought over some other improvements from Linux. Aside from adding additional code comments, I have added better error logging regarding i2c transaction aborts. (It now detects the reason for the abort and prints out a description based on the structs in the Linux driver).

We have tested these updates on the Haswell Acer C720 Chromebook (Cypress trackpad + Atmel touch screen), Broadwell Acer C740 Chromebook (Elan Trackpad), blankmac's Skylake HP Elite X2 1012 (Wacom touch + stylus), and alexviean's Skylake Asus K501UB-DM039D (Elan Trackpad) and it works on all 4 configurations 😄 