### PR TITLE
Minor code cleanups. Allow use on OS X Mavericks.

### DIFF
--- a/VoodooI2C/Info.plist
+++ b/VoodooI2C/Info.plist
@@ -56,11 +56,11 @@
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>2.0</string>
 		<key>com.apple.kpi.iokit</key>
-		<string>14.0</string>
+		<string>13.0</string>
 		<key>com.apple.kpi.libkern</key>
-		<string>14.0</string>
+		<string>13.0</string>
 		<key>com.apple.kpi.mach</key>
-		<string>14.0</string>
+		<string>13.0</string>
 	</dict>
 </dict>
 </plist>

--- a/VoodooI2C/VoodooAtmelTouchWrapper.cpp
+++ b/VoodooI2C/VoodooAtmelTouchWrapper.cpp
@@ -23,10 +23,12 @@ static VoodooI2CAtmelMxtScreenDevice* GetOwner(const IOService *us)
 bool VoodooAtmelTouchWrapper::start(IOService *provider) {
     if (OSDynamicCast(VoodooI2CAtmelMxtScreenDevice, provider) == NULL)
         return false;
+    if (!IOHIDDevice::start(provider))
+        return false;
 
     IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     setProperty("HIDDefaultBehavior", OSString::withCString("Trackpad"));
-    return IOHIDDevice::start(provider);
+    return true;
 }
 
 IOReturn VoodooAtmelTouchWrapper::setProperties(OSObject *properties) {

--- a/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIDWrapper.cpp
@@ -12,8 +12,10 @@
 OSDefineMetaClassAndStructors(VoodooCSGestureHIDWrapper, IOHIDDevice)
 
 bool VoodooCSGestureHIDWrapper::start(IOService *provider) {
+    if (!IOHIDDevice::start(provider))
+        return false;
     setProperty("HIDDefaultBehavior", OSString::withCString("Trackpad"));
-    return IOHIDDevice::start(provider);
+    return true;
 }
 
 IOReturn VoodooCSGestureHIDWrapper::setProperties(OSObject *properties) {

--- a/VoodooI2C/VoodooCyapaGen3Device.cpp
+++ b/VoodooI2C/VoodooCyapaGen3Device.cpp
@@ -45,8 +45,7 @@ bool VoodooI2CCyapaGen3Device::attach(IOService * provider, IOService* child)
 {
     if (!super::attach(provider))
         return false;
-    
-    assert(_controller == 0);
+
     _controller = (VoodooI2C*)provider;
     _controller->retain();
     

--- a/VoodooI2C/VoodooElanTouchpadDevice.cpp
+++ b/VoodooI2C/VoodooElanTouchpadDevice.cpp
@@ -98,8 +98,7 @@ bool VoodooI2CElanTouchpadDevice::attach(IOService * provider, IOService* child)
 {
     if (!super::attach(provider))
         return false;
-    
-    assert(_controller == 0);
+
     _controller = (VoodooI2C*)provider;
     _controller->retain();
     

--- a/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
+++ b/VoodooI2C/VoodooI2CAtmelMxtScreenDevice.cpp
@@ -167,7 +167,6 @@ bool VoodooI2CAtmelMxtScreenDevice::attach(IOService * provider, IOService* chil
     if (!super::attach(provider))
         return false;
     
-    assert(_controller == 0);
     _controller = (VoodooI2C*)provider;
     _controller->retain();
     


### PR DESCRIPTION
Do some minor code cleanup to try to follow OS X kext coding conventions.

Allow use of the kext on OS X Mavericks; installed Mavericks on a partition here to run some tests and I found the kext works fine on Mavericks with some small minor changes.