### PR TITLE
Sierra pref pane enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-This fork contains the adjustments and added multitouch functionality for the HP Elite X2 1012
-
-
 # VoodooI2C
 
 VoodooI2C is a project to bring support for I2C input devices to OS X. This repository contains code for both I2C controllers and I2C devices.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following devices are confirmed to work with the current iteration of Voodoo
 * Atmel 1000 touchscreen (Dell XPS 12)
 * NTRG 0001 touchscreen (Surface Pro 3)
 * FTSC1000 touchscreen (Cube i7)
-* WCOM4818 touch screen + stylus (Skylake HP Elite X2 1012)
+* WCOM4814 touch screen + stylus (Skylake HP Elite X2 1012)
 * CYAP0000 trackpad (Haswell Chromebooks)
  * This uses the proprietary interface `VoodooCyapaGen3Device`.
 * ATML0001 touchscreen (Acer C720P Chromebook/Chromebook Pixel 2)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This fork contains the adjustments and added multitouch functionality for the HP Elite X2 1012
+
+
 # VoodooI2C
 
 VoodooI2C is a project to bring support for I2C input devices to OS X. This repository contains code for both I2C controllers and I2C devices.

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -9,6 +9,8 @@
 #include <IOKit/IOLib.h>
 #include <IOKit/hidsystem/IOHIDParameter.h>
 #include "VoodooCSGestureHIPointingWrapper.h"
+#include <libkern/version.h>
+
 
 OSDefineMetaClassAndStructors(VoodooCSGestureHIPointingWrapper, IOHIPointing);
 
@@ -41,6 +43,21 @@ bool VoodooCSGestureHIPointingWrapper::start(IOService *provider){
     if (!super::start(provider))
         return false;
     
+    if (version_major>=16) {
+        
+        setProperty("SupportsGestureScrolling", true);
+        setProperty("TrackpadFourFingerGestures", false);
+        setProperty("ApplePreferenceIdentifier", "com.apple.AppleMultitouchTrackpad");
+        setProperty("MTHIDDevice", true);
+        setProperty("MT Built-in", true);
+        setProperty("ApplePreferenceCapability", true);
+        setProperty("TrackpadEmbedded", true);
+        setProperty("TrackpadThreeFingerDrag", false);
+        
+    }
+    
+    
+    
     int enabledProperty = 1;
     setProperty("Clicking", enabledProperty,
                 sizeof(enabledProperty) * 8);
@@ -48,6 +65,8 @@ bool VoodooCSGestureHIPointingWrapper::start(IOService *provider){
                 sizeof(enabledProperty) * 8);
     setProperty("TrackpadHorizScroll", enabledProperty,
                 sizeof(enabledProperty) * 8);
+    
+    
     
     //
     // Must add this property to let our superclass know that it should handle
@@ -67,6 +86,9 @@ bool VoodooCSGestureHIPointingWrapper::start(IOService *provider){
     setProperty(kIOHIDPointerAccelerationTypeKey, kIOHIDTrackpadAccelerationType);
     setProperty(kIOHIDScrollAccelerationTypeKey, kIOHIDTrackpadScrollAccelerationKey);
     setProperty(kIOHIDScrollResolutionKey, 800 << 16, 32);
+    
+    setProperty("HIDScrollResolutionX", 800 << 16, 32);
+    setProperty("HIDScrollResolutionY", 800 << 16, 32);
     
     return true;
 }
@@ -95,9 +117,9 @@ void VoodooCSGestureHIPointingWrapper::updateScroll(short dy, short dx, short dz
 
 IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict)
 {
- 
+    
     /*Known Keys:
-        HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
+     HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
     OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
     if (clicking){


### PR DESCRIPTION
Checks the Darwin version before applying the properties to enable the preference pane.  Adds "precise" scrolling properties (tested and working)  The preference pane is enabled, however, the only tester reports that he has to toggle the click setting on reboot.  On my machine, the click setting is persistent, but unused so I can't test.