### PR TITLE
Force enabling 'Tap to click' and 'dragging'

### DIFF
--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -121,15 +121,9 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
     /*Known Keys:
      HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
-    OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
-    if (clicking){
-        gesturerec->softc->settings.tapToClickEnabled = clicking->unsigned32BitValue() & 0x1;
-    }
+    gesturerec->softc->settings.tapToClickEnabled = true;
     
-    OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
-    if (dragging){
-        gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
-    }
+    gesturerec->softc->settings.tapDragEnabled = true;
     
     gesturerec->softc->settings.multiFingerTap = true;
     

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -121,9 +121,23 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
     /*Known Keys:
      HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
-    gesturerec->softc->settings.tapToClickEnabled = true;
-    
-    gesturerec->softc->settings.tapDragEnabled = true;
+    if (version_major >= 16) {
+        //Can't read trackpad preferences on macOS Sierra (Darwin 16), defaulting to true:
+        gesturerec->softc->settings.tapToClickEnabled = true;
+        
+        gesturerec->softc->settings.tapDragEnabled = true;
+    }
+    else {
+        OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+        if (clicking){
+            gesturerec->softc->settings.tapToClickEnabled = clicking->unsigned32BitValue() & 0x1;
+        }
+        
+        OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+        if (dragging){
+            gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
+        }
+    }
     
     gesturerec->softc->settings.multiFingerTap = true;
     


### PR DESCRIPTION
Until read from preferences would work, it's better to have it enabled.
Changes from System Preferences won't take effect now.