### PR TITLE
Properly initialise the RMI device (as per Linux kernel)

### DIFF
--- a/VoodooI2C/VoodooSynapticsRMITouchpadDevice.cpp
+++ b/VoodooI2C/VoodooSynapticsRMITouchpadDevice.cpp
@@ -936,7 +936,7 @@ int VoodooSynapticsRMITouchpadDevice::rmi_set_mode(uint8_t mode) {
 int VoodooSynapticsRMITouchpadDevice::rmi_populate() {
     int ret;
     
-    ret = rmi_set_mode(0);
+    ret = rmi_set_mode(RMI_MODE_ATTN_REPORTS);
     if (ret) {
         IOLog("%s::%s::PDT set mode failed with code %d\n", getName(), _controller->_dev->name, ret);
         return ret;


### PR DESCRIPTION
I noticed that the Linux sets a different RMI mode (see https://github.com/torvalds/linux/blob/master/drivers/hid/hid-rmi.c#L480) and this seems to get basic multitouch working on my laptop.

You should also note that for proper device support, you will need to modify the if/else statement in VoodooI2C.cpp

