### PR TITLE
Fix preference pane issue on macOS Sierra

### DIFF
--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -121,37 +121,47 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
     /*Known Keys:
      HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
-    /*
-     Notes:
-     Sierra fix requires the cast to be changed to OSBoolean
-     Below chunk of code should work in El Captain and lower (untested)
-     */
-    
-    OSBoolean *bool_clicking = OSDynamicCast(OSBoolean, dict->getObject("Clicking"));
-    OSNumber *num_clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
-    if (num_clicking ){
-        gesturerec->softc->settings.tapToClickEnabled = num_clicking->unsigned32BitValue() & 0x1;
-    } else if(bool_clicking) {
-        gesturerec->softc->settings.tapToClickEnabled = bool_clicking->isTrue();
-    }
-    
-    OSBoolean *bool_dragging = OSDynamicCast(OSBoolean, dict->getObject("Dragging"));
-    OSNumber *num_dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
-    if (num_dragging) {
-        gesturerec->softc->settings.tapDragEnabled = num_dragging->unsigned32BitValue() & 0x1;
-    }else if (bool_dragging){
-        gesturerec->softc->settings.tapDragEnabled = bool_dragging->isTrue();
+    if (version_major >= 16){
+        /*
+        macOS 10.12 (and above)
+        Sierra fix requires the cast to be changed to OSBoolean
+        */
+        
+        OSBoolean *clicking = OSDynamicCast(OSBoolean, dict->getObject("Clicking"));
+        if(clicking) {
+            gesturerec->softc->settings.tapToClickEnabled = clicking->isTrue();
+        }
+        
+        OSBoolean *dragging = OSDynamicCast(OSBoolean, dict->getObject("Dragging"));
+        if (dragging){
+            gesturerec->softc->settings.tapDragEnabled = dragging->isTrue();
+        }
+        
+        OSBoolean *hscroll  = OSDynamicCast(OSBoolean, dict->getObject("TrackpadHorizScroll"));
+        if (hscroll){
+            horizontalScroll = hscroll->isTrue();
+        }
+        
+    } else {
+        //OS X 10.11 and below
+        
+        OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+        if (clicking ){
+            gesturerec->softc->settings.tapToClickEnabled = clicking->unsigned32BitValue() & 0x1;
+        }
+        
+        OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+        if (dragging) {
+            gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
+        }
+        
+        OSNumber *hscroll = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
+        if(hscroll) {
+            horizontalScroll = hscroll->unsigned32BitValue() & 0x1;
+        }
     }
     
     gesturerec->softc->settings.multiFingerTap = true;
-    
-    OSBoolean *bool_hscroll  = OSDynamicCast(OSBoolean, dict->getObject("TrackpadHorizScroll"));
-    OSNumber *num_hscroll = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
-    if(num_hscroll) {
-        horizontalScroll = num_hscroll->>unsigned32BitValue() & 0x1;
-    } else if (bool_hscroll){
-        horizontalScroll = bool_hscroll->isTrue();
-    }
     
     return super::setParamProperties(dict);
 }

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -121,21 +121,27 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
     /*Known Keys:
      HIDDefaultParameters, HIDClickTime, HIDClickSpace, HIDKeyRepeat, HIDInitialKeyRepeat, HIDPointerAcceleration, HIDScrollAcceleration, HIDPointerButtonMode, HIDF12EjectDelay, EjectDelay, HIDSlowKeysDelay, HIDStickyKeysDisabled, HIDStickyKeysOn, HIDStickyKeysShiftToggles, HIDMouseKeysOptionToggles, HIDFKeyMode, HIDMouseKeysOn, HIDKeyboardModifierMappingPairs, MouseKeysStopsTrackpad, HIDScrollZoomModifierMask, HIDMouseAcceleration, HIDMouseScrollAcceleration, HIDTrackpadAcceleration, HIDTrackpadScrollAcceleration, TrackpadPinch, TrackpadFourFingerVertSwipeGesture, TrackpadRotate, TrackpadHorizScroll, TrackpadFourFingerPinchGesture, TrackpadTwoFingerDoubleTapGesture, TrackpadMomentumScroll, TrackpadThreeFingerTapGesture, TrackpadThreeFingerHorizSwipeGesture, Clicking, TrackpadScroll, DragLock, TrackpadFiveFingerPinchGesture, TrackpadThreeFingerVertSwipeGesture, TrackpadTwoFingerFromRightEdgeSwipeGesture, Dragging, TrackpadRightClick, TrackpadCornerSecondaryClick, TrackpadFourFingerHorizSwipeGesture, TrackpadThreeFingerDrag, JitterNoMove, JitterNoClick, PalmNoAction When Typing, PalmNoAction Permanent, TwofingerNoAction, OutsidezoneNoAction When Typing, Use Panther Settings for W, Trackpad Jitter Milliseconds, USBMouseStopsTrackpad, HIDWaitCursorFrameInterval*/
     
-    OSNumber *clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+    /*
+     Notes:
+     Sierra fix requires the cast to be changed to OSBoolean
+     Below chunk of code should work in El Captain and lower (untested)
+     */
+    
+    OSBoolean *clicking = OSDynamicCast(OSBoolean, dict->getObject("Clicking"));
     if (clicking){
-        gesturerec->softc->settings.tapToClickEnabled = clicking->unsigned32BitValue() & 0x1;
+        gesturerec->softc->settings.tapToClickEnabled = clicking->isTrue();
     }
     
-    OSNumber *dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+    OSBoolean *dragging = OSDynamicCast(OSBoolean, dict->getObject("Dragging"));
     if (dragging){
-        gesturerec->softc->settings.tapDragEnabled = dragging->unsigned32BitValue() & 0x1;
+        gesturerec->softc->settings.tapDragEnabled = dragging->isTrue();
     }
     
     gesturerec->softc->settings.multiFingerTap = true;
     
-    OSNumber *hscroll  = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
+    OSBoolean *hscroll  = OSDynamicCast(OSBoolean, dict->getObject("TrackpadHorizScroll"));
     if (hscroll){
-        horizontalScroll = hscroll->unsigned32BitValue() & 0x1;
+        horizontalScroll = hscroll->isTrue();
     }
     return super::setParamProperties(dict);
 }

--- a/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
+++ b/VoodooI2C/VoodooCSGestureHIPointingWrapper.cpp
@@ -127,22 +127,32 @@ IOReturn VoodooCSGestureHIPointingWrapper::setParamProperties(OSDictionary *dict
      Below chunk of code should work in El Captain and lower (untested)
      */
     
-    OSBoolean *clicking = OSDynamicCast(OSBoolean, dict->getObject("Clicking"));
-    if (clicking){
-        gesturerec->softc->settings.tapToClickEnabled = clicking->isTrue();
+    OSBoolean *bool_clicking = OSDynamicCast(OSBoolean, dict->getObject("Clicking"));
+    OSNumber *num_clicking = OSDynamicCast(OSNumber, dict->getObject("Clicking"));
+    if (num_clicking ){
+        gesturerec->softc->settings.tapToClickEnabled = num_clicking->unsigned32BitValue() & 0x1;
+    } else if(bool_clicking) {
+        gesturerec->softc->settings.tapToClickEnabled = bool_clicking->isTrue();
     }
     
-    OSBoolean *dragging = OSDynamicCast(OSBoolean, dict->getObject("Dragging"));
-    if (dragging){
-        gesturerec->softc->settings.tapDragEnabled = dragging->isTrue();
+    OSBoolean *bool_dragging = OSDynamicCast(OSBoolean, dict->getObject("Dragging"));
+    OSNumber *num_dragging = OSDynamicCast(OSNumber, dict->getObject("Dragging"));
+    if (num_dragging) {
+        gesturerec->softc->settings.tapDragEnabled = num_dragging->unsigned32BitValue() & 0x1;
+    }else if (bool_dragging){
+        gesturerec->softc->settings.tapDragEnabled = bool_dragging->isTrue();
     }
     
     gesturerec->softc->settings.multiFingerTap = true;
     
-    OSBoolean *hscroll  = OSDynamicCast(OSBoolean, dict->getObject("TrackpadHorizScroll"));
-    if (hscroll){
-        horizontalScroll = hscroll->isTrue();
+    OSBoolean *bool_hscroll  = OSDynamicCast(OSBoolean, dict->getObject("TrackpadHorizScroll"));
+    OSNumber *num_hscroll = OSDynamicCast(OSNumber, dict->getObject("TrackpadHorizScroll"));
+    if(num_hscroll) {
+        horizontalScroll = num_hscroll->>unsigned32BitValue() & 0x1;
+    } else if (bool_hscroll){
+        horizontalScroll = bool_hscroll->isTrue();
     }
+    
     return super::setParamProperties(dict);
 }
 


### PR DESCRIPTION
Rehabman uses OSBoolean instead of OSNumber (see https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller/blob/master/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp#L2518)

Not tested on macOS versions lower and including 10.11 (El Captain), but should work nonetheless. 