### PR TITLE
allow _DSM or XDSM for HID data acquisition; and avoid KP if both are missing

### DIFF
--- a/VoodooI2C/VoodooI2CHIDDevice.cpp
+++ b/VoodooI2C/VoodooI2CHIDDevice.cpp
@@ -245,12 +245,17 @@ int VoodooI2CHIDDevice::i2c_hid_acpi_pdata(i2c_hid *ihid) {
     params[2] = OSNumber::withNumber(0x1, 8);
     
     ihid->client->provider->evaluateObject("_DSM", &result, params, 3);
+    if (!result)
+        ihid->client->provider->evaluateObject("XDSM", &result, params, 3);
+
 
     OSNumber* number = OSDynamicCast(OSNumber, result);
-    
-    ihid->pdata.hid_descriptor_address = number->unsigned32BitValue();
-    
-    number->release();
+    if (number)
+        ihid->pdata.hid_descriptor_address = number->unsigned32BitValue();
+
+    if (result)
+        result->release();
+
     params[0]->release();
     params[1]->release();
     params[2]->release();


### PR DESCRIPTION
It is very common to rename _DSM methods in DSDT (and other ACPI files) to XDSM, so that additional _DSM methods can be added (either through patching or via add-on SSDTs) without conflict.

I use hotpatch for _DSM->XDSM (via config.plist/ACPI/DSDT/Patches).  Doing _DSM->XDSM rename, excluding the I2C from the rename would be difficult (to say the least).

This poses a problem with this kext, as it KPs when the expected _DSM method is not found.  Ideally, a kext should not KP due to user error.

I made two improvements here:
- no KP if the expected _DSM does not evaluate without error
- both _DSM and XDSM are allowed

This allows _DSM or XDSM (compatible with _DSM->XDSM hotpatch), and should the user mistakenly remove all _DSM methods from their DSDT, they will not get a KP...

I have no I2C hardware, but I proposed this change for other users...