### PR TITLE
Default tapToClickEnabled to true

### DIFF
--- a/VoodooI2C/csgesture-softc.h
+++ b/VoodooI2C/csgesture-softc.h
@@ -6,7 +6,7 @@
 
 struct csgesture_settings { //note not all settings were brought over from Windows as we are using Apple's settings panel
     //tap settings
-    bool tapToClickEnabled;
+    bool tapToClickEnabled = true;
     bool multiFingerTap;
     bool tapDragEnabled;
 };


### PR DESCRIPTION
For tap to click inside the lock screen, until settings are read from user's preferences (after login).