### PR TITLE
Fix verbose boot issues

### DIFF
--- a/VoodooI2C/csgesture.cpp
+++ b/VoodooI2C/csgesture.cpp
@@ -624,10 +624,10 @@ void CSGesture::wakeFromSleep(){
 void CSGesture::initialize_wrapper(IOService *service) {
     destroy_wrapper();
     
-    IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+    //IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
     _wrapper = new VoodooCSGestureHIDWrapper;
     if (_wrapper->init()) {
-        IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
+        //IOLog("VoodooI2C: %s, line %d\n", __FILE__, __LINE__);
         _wrapper->gestureEngine = this;
         _wrapper->attach(service);
         _wrapper->start(service);


### PR DESCRIPTION
Commenting out 2 logging lines which caused kernel panics in a few devices when booting verbose.