### PR TITLE
Potenial fix for the 2F tap not working after momentum scroll

### DIFF
--- a/Multitouch Support/CSGesture/VoodooI2CCSGestureEngine.cpp
+++ b/Multitouch Support/CSGesture/VoodooI2CCSGestureEngine.cpp
@@ -626,7 +626,7 @@ void VoodooI2CCSGestureEngine::ProcessGesture(csgesture_softc *sc) {
                 iToUse[a] = i;
                 a++;
             }
-        } else {
+        } else if (distancesq(avgx[i], avgy[i]) > 2) {
             abovethreshold++;
             iToUse[a] = i;
             a++;


### PR DESCRIPTION
This may need additional testing because of the conditional change. I have no idea if the underlying intended behaviour will be changed with this change.

However, this does fix the 2F tap not working after scroll is initiated.