### PR TITLE
Allow waiting for the GPIO controller

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,6 @@
 [submodule "VoodooI2C Satellites/VoodooI2CSynaptics"]
 	path = VoodooI2C Satellites/VoodooI2CSynaptics
 	url = https://github.com/alexandred/VoodooI2CSynaptics.git
-
 [submodule "VoodooI2C Satellites/VoodooI2CFTE"]
 	path = VoodooI2C Satellites/VoodooI2CFTE
-	url = https://github.com/alexandred/VoodooI2CFTE
+	url = https://github.com/prizraksarvar/VoodooI2CFTE.git

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -141,21 +141,20 @@ exit:
 
 VoodooGPIO* VoodooI2CDeviceNub::getGPIOController() {
     VoodooGPIO* gpio_controller = NULL;
-
-    OSDictionary *match = serviceMatching("VoodooGPIO");
-    OSIterator *iterator = getMatchingServices(match);
-    if (iterator) {
-        gpio_controller = OSDynamicCast(VoodooGPIO, iterator->getNextObject());
-
-        if (gpio_controller != NULL) {
-            IOLog("%s::Got GPIO Controller! %s\n", getName(), gpio_controller->getName());
-        }
-
-        gpio_controller->retain();
-
-        iterator->release();
+    
+    // Wait for GPIO controller, up to 1 second
+    OSDictionary* name_match = OSDictionary::withCapacity(1);
+    name_match = IOService::serviceMatching("VoodooGPIO");
+    
+    IOService* matched = waitForMatchingService(name_match, 1000000000);
+    gpio_controller = OSDynamicCast(VoodooGPIO, matched);
+    
+    if (gpio_controller != NULL) {
+        IOLog("%s::Got GPIO Controller! %s\n", getName(), gpio_controller->getName());
     }
-
+    name_match->release();
+    OSSafeReleaseNULL(matched);
+    
     return gpio_controller;
 }
 


### PR DESCRIPTION
Refactored VoodooI2CDeviceNub::getGPIOController() so it waits (up to 1 second) for the GPIO controller if not available.