### PR TITLE
Fix multitouch finger count when transducer 0 is a stylus.

### DIFF
--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
@@ -40,6 +40,9 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
     if (!transducer)
         return;
     
+    if (transducer->type==kDigitiserTransducerStylus)
+        stylus_check = 1;
+    
     // physical button
     input_report.Button = transducer->physical_button.value();
     
@@ -67,7 +70,7 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
     bool input_active = false;
     
     for (int i = 0; i < multitouch_event.contact_count + 1; i++) {
-        VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, multitouch_event.transducers->getObject(i));
+        VoodooI2CDigitiserTransducer* transducer = OSDynamicCast(VoodooI2CDigitiserTransducer, multitouch_event.transducers->getObject(i + stylus_check));
         
         new_touch_state[i] = touch_state[i];
         touch_state[i] = 0;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -100,6 +100,7 @@ private:
     UInt8 touch_state[15];
     UInt8 new_touch_state[15];
     int last_finger_count;
+    int stylus_check = 0;
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;
     MAGIC_TRACKPAD_INPUT_REPORT input_report;


### PR DESCRIPTION
I was making this fix unnecessarily complicated in the past.  All that is needed is a check for a stylus at transducer 0, if this is true then we offset the subsequent transducers so that the native multitouch engine populates transducers 1-5 as fingers 0-4 in the multitouch data.  This is tested on my device with a stylus and works under all conditions.  The changes still need to be tested on a device which does not have a stylus, but looking at the logic I can't see how it would be an issue.