### PR TITLE
Input lags when using GPIO interrupts in v2.1.4+

### DIFF
--- a/Dependencies/VoodooI2CServices/VoodooI2CServices/Info.plist
+++ b/Dependencies/VoodooI2CServices/VoodooI2CServices/Info.plist
@@ -54,5 +54,7 @@
 		<key>com.apple.kpi.libkern</key>
 		<string>14</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
 </dict>
 </plist>

--- a/Multitouch Support/CSGesture/VoodooI2CCSGestureEngine.cpp
+++ b/Multitouch Support/CSGesture/VoodooI2CCSGestureEngine.cpp
@@ -141,9 +141,9 @@ MultitouchReturn VoodooI2CCSGestureEngine::handleInterruptReport(VoodooI2CMultit
                     }
 
                     if (transform & kIOFBInvertX)
-                    softc.x[i] = (interface->logical_max_x / softc.factor_x) - softc.x[i];
+                        softc.x[i] = (interface->logical_max_x / softc.factor_x) - softc.x[i];
                     if (transform & kIOFBInvertY)
-                        softc.y[i] = (interface->logical_max_y / softc.factor_y) - softc.x[i];
+                        softc.y[i] = (interface->logical_max_y / softc.factor_y) - softc.y[i];
                 }
                 
                 if (transducer->tip_pressure.value())

--- a/Multitouch Support/CSGesture/csgesturescroll.cpp
+++ b/Multitouch Support/CSGesture/csgesturescroll.cpp
@@ -295,13 +295,17 @@ bool CSGestureScroll::start(IOService *provider){
 
 void CSGestureScroll::stop(){
     if (_scrollTimer){
-        _scrollTimer->cancelTimeout();
+        _scrollTimer->cancelTimeout();  // disable before removal.
+        if (_workLoop)
+            _workLoop->removeEventSource(_scrollTimer);
         _scrollTimer->release();
         _scrollTimer = NULL;
     }
     
     if (_disableScrollDelayTimer){
         _disableScrollDelayTimer->cancelTimeout();
+        if (_workLoop)
+            _workLoop->removeEventSource(_disableScrollDelayTimer);
         _disableScrollDelayTimer->release();
         _disableScrollDelayTimer = NULL;
     }

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
@@ -103,22 +103,27 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
         SInt16 x_min = 3678;
         SInt16 y_min = 2479;
         
-        IOFixed scaled_x = ((transducer->coordinates.x.value() * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_X;
-        IOFixed scaled_y = ((transducer->coordinates.y.value() * 1.0f) / engine->interface->logical_max_y) * MT2_MAX_Y;
+        // IOFixed scaled_x = ((transducer->coordinates.x.value() * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_X;
+        // IOFixed scaled_y = ((transducer->coordinates.y.value() * 1.0f) / engine->interface->logical_max_y) * MT2_MAX_Y;
+        IOFixed scaled_x = ((IOFixed)transducer->coordinates.x.value() * MT2_MAX_X) / engine->interface->logical_max_x;
+        IOFixed scaled_y = ((IOFixed)transducer->coordinates.y.value() * MT2_MAX_Y) / engine->interface->logical_max_y;
 
         if (scaled_x < 1 && scaled_y >= MT2_MAX_Y) {
             is_error_input_active = true;
         }
         
-        IOFixed scaled_old_x = ((transducer->coordinates.x.last.value * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_X;
-        
+        // IOFixed scaled_old_x = ((transducer->coordinates.x.last.value * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_X;
+        IOFixed scaled_old_x = ((IOFixed)transducer->coordinates.x.last.value * MT2_MAX_X) / (IOFixed)engine->interface->logical_max_x;
+
         uint8_t scaled_old_x_truncated = scaled_old_x;
 
         
         if (transform) {
             if (transform & kIOFBSwapAxes) {
-                scaled_x = ((transducer->coordinates.y.value() * 1.0f) / engine->interface->logical_max_y) * MT2_MAX_X;
-                scaled_y = ((transducer->coordinates.x.value() * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_Y;
+                // scaled_x = ((transducer->coordinates.y.value() * 1.0f) / engine->interface->logical_max_y) * MT2_MAX_X;
+                // scaled_y = ((transducer->coordinates.x.value() * 1.0f) / engine->interface->logical_max_x) * MT2_MAX_Y;
+                scaled_x = ((IOFixed)transducer->coordinates.y.value() * MT2_MAX_X) / (IOFixed)engine->interface->logical_max_y;
+                scaled_y = ((IOFixed)transducer->coordinates.x.value() * MT2_MAX_Y) / (IOFixed)engine->interface->logical_max_x;
             }
             
             if (transform & kIOFBInvertX) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -43,26 +43,6 @@ IOReturn VoodooI2CControllerDriver::getBusConfig() {
         return kIOReturnSuccess;
 }
 
-IOWorkLoop* VoodooI2CControllerDriver::getWorkLoop() {
-    // Do we have a work loop already?, if so return it NOW.
-    if ((vm_address_t) work_loop >> 1)
-        return work_loop;
-
-    if (OSCompareAndSwap(0, 1, reinterpret_cast<IOWorkLoop*>(&work_loop))) {
-        // Construct the workloop and set the cntrlSync variable
-        // to whatever the result is and return
-        work_loop = IOWorkLoop::workLoop();
-    } else {
-        while (reinterpret_cast<IOWorkLoop*>(work_loop) == reinterpret_cast<IOWorkLoop*>(1)) {
-            // Spin around the cntrlSync variable until the
-            // initialization finishes.
-            thread_block(0);
-        }
-    }
-
-    return work_loop;
-}
-
 void VoodooI2CControllerDriver::handleAbortI2C() {
     IOLog("%s::%s I2C Transaction error details\n", getName(), bus_device->name);
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -160,8 +160,6 @@ class VoodooI2CControllerDriver : public IOService {
 
     IOReturn getBusConfig();
 
-    IOWorkLoop* getWorkLoop();
-
     /* Prints an error message when the bus reports a transaction error */
 
     void handleAbortI2C();

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -166,6 +166,7 @@ IOReturn VoodooI2CDeviceNub::getInterruptType(int source, int* interrupt_type) {
 }
 
 IOWorkLoop* VoodooI2CDeviceNub::getWorkLoop(void) const {
+    // 0x00000000 = not initialized. 0x00000001 = busy. 0xXXXXXXXX = initialized.
     static IOWorkLoop* __work_loop = NULL;
 
     // Do we have a work loop already?, if so return it NOW.
@@ -188,7 +189,7 @@ IOWorkLoop* VoodooI2CDeviceNub::getWorkLoop(void) const {
 }
 
 IOReturn VoodooI2CDeviceNub::readI2C(UInt8* values, UInt16 length) {
-    return command_gate->runAction(OSMemberFunctionCast(IOCommandGate::Action, this, &VoodooI2CDeviceNub::readI2CGated), values, &length);
+    return command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &VoodooI2CDeviceNub::readI2CGated), values, &length);
 }
 
 IOReturn VoodooI2CDeviceNub::readI2CGated(UInt8* values, UInt16* length) {
@@ -226,7 +227,7 @@ void VoodooI2CDeviceNub::releaseResources() {
     }
 
     if (work_loop) {
-        // work_loop->release();
+        work_loop->release();
         work_loop = NULL;
     }
 }

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -83,7 +83,7 @@ class VoodooI2CDeviceNub : public IOService {
      * the nub itself along with any drivers that attach to it.
      * @return A pointer to an *IOWorkLoop* object, else *NULL*
      */
-    IOWorkLoop* getWorkLoop();
+    IOWorkLoop* getWorkLoop(void) const override;
 
     /* Transmits an I2C read request to the slave device
      * @values The buffer that the returned data is to be written into


### PR DESCRIPTION
getWorkLoop in VoodooI2CControllerDriver.cpp and VoodooGPIO.cpp, which was added after 2.1.4 release, were causing the issue. Removing the local method solves the issue. It's related with #192.