### PR TITLE
Correct IOCommandGate::commandSleep call

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -176,9 +176,9 @@ IOReturn VoodooI2CControllerDriver::prepareTransferI2C(VoodooI2CControllerBusMes
 
     nanoseconds_to_absolutetime(10000, &abstime);
 
-    sleep = command_gate->commandSleep(&bus_device.command_complete, (UInt32)abstime);
+    sleep = command_gate->commandSleep(&bus_device.command_complete, abstime, THREAD_UNINT);
 
-    if ( sleep == THREAD_TIMED_OUT ) {
+    if (sleep == THREAD_TIMED_OUT) {
         IOLog("%s::%s Timeout waiting for bus to accept transfer request\n", getName(), bus_device.name);
         initialiseBus();
         return kIOReturnTimeout;


### PR DESCRIPTION
`IOCommandGate::commandSleep` has the following signatures:

```cpp
virtual IOReturn commandSleep(
 void *event,
 AbsoluteTime deadline,
 UInt32 interruptible);

virtual IOReturn commandSleep(
 void *event,
 UInt32 interruptible);
```

Previously, `commandSleep` was called with 2 arguments, with the deadline
being passed in as `interruptible`, which is incorrect. Explicitly specify
`THREAD_UNINT` as `interruptible` to use the first signature and correctly
specify the deadline.
