### PR TITLE
Fix Unknown Synopsys component type issue in Comet Lake 2nd

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -12,11 +12,43 @@
 OSDefineMetaClassAndStructors(VoodooI2CPCIController, VoodooI2CController);
 
 void VoodooI2CPCIController::configurePCI() {
-    IOLog("%s::%s Set PCI power state D0\n", getName(), physical_device.name);
-    physical_device.pci_device->enablePCIPowerManagement(kPCIPMCSPowerStateD0);
+    char tmp[2];
+    const char kCometLakeflag[2] = {'2', 'e'};
 
-    physical_device.pci_device->setBusMasterEnable(true);
-    physical_device.pci_device->setMemoryEnable(true);
+    IOLog("%s::%s Set PCI power state D0\n", getName(), physical_device.name);
+    auto pci_device = physical_device.pci_device;
+    pci_device->enablePCIPowerManagement(kPCIPMCSPowerStateD0);
+
+    /* To apply this patch, we need to check if it's 10th Comet Lake CPU
+       because this hack patch can't work in other platforms like 8th Kaby Lake R.
+       Every 10th CPU 's id includes "2e" in the index 8 and index9, which can be used to check the
+       platform. Thx for @Williambj1 's discovery.*/
+
+    OSString *mystring = OSString::withCString(physical_device.name);
+    if (!mystring) {
+        IOLog("%s::%s Get IONameMatched data error!\n", getName(), physical_device.name);
+        return;
+    }
+
+    // Write your computer 's id flag for comparision
+    tmp[0] = mystring->getChar(8);
+    tmp[1] = mystring->getChar(9);
+
+
+    /* If it is Comet Lake, then let's apply Forcing D0 here.
+       It will modify 0x80 below to your findings.*/
+
+    if (tmp[0] == kCometLakeflag[0] && tmp[1] == kCometLakeflag[1]) {
+        IOLog("%s::%s Current CPU is Comet Lake, patching...\n", getName(), physical_device.name);
+        uint16_t oldPowerStateWord = pci_device->configRead16(0x80 + 0x4);
+        uint16_t newPowerStateWord = (oldPowerStateWord & (~0x3)) | 0x0;
+        // Modify 0x80 below to your findings.
+        pci_device->configWrite16(0x80 + 0x4, newPowerStateWord);
+        IOLog("%s::%s Successfully patched!\n", getName(), physical_device.name);
+    }
+
+    pci_device->setBusMasterEnable(true);
+    pci_device->setMemoryEnable(true);
 }
 
 IOReturn VoodooI2CPCIController::getACPIDevice() {


### PR DESCRIPTION
This commit has fixed the issue #236 . This work is based on https://www.notion.so/Using-VoodooI2C-on-comet-lake-cpu-e-g-i5-10210u-142930887087445eaa533120455da5dc , which will force D0 in Comet Lake. And I completed it to check the platform to avoid this patch to be applied in other platforms. See code comments for more details.