### PR TITLE
Improve multitouch

### DIFF
--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
@@ -179,6 +179,7 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
         finger_data.Size = 10;
         finger_data.Touch_Minor = 20;
         finger_data.Touch_Major = 20;
+        finger_data.Pressure = 10;
         
         if (transducer->tip_pressure.value() || (input_report.Button)) {
             finger_data.Pressure = 120;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
@@ -87,8 +87,9 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
             continue;
         }
         
+        UInt16 finger_id = transducer->secondary_id % 15; // in case the obtained id is greater than 14, usually 0~4 for common devices.
         if (!transducer->tip_switch.value()) {
-            touch_state[i] = 0;
+            touch_state[finger_id] = 0;
         } else {
             input_active = true;
         }
@@ -167,11 +168,11 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
             }
         }
 
-        touch_state[i]++;
-        if (touch_state[i] > 4) {
+        touch_state[finger_id]++;
+        if (touch_state[finger_id] > 4) {
             finger_data.State = 0x4;
         } else {
-            finger_data.State = touch_state[i];
+            finger_data.State = touch_state[finger_id];
         }
         
         finger_data.Priority = 4 - i;
@@ -197,7 +198,7 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
         finger_data.Y = (SInt16)(scaled_y - y_min) * -1;
         
         finger_data.Angle = angle_bits;
-        finger_data.Identifier = transducer->secondary_id + 1;
+        finger_data.Identifier = finger_id + 1;
     }
 
     if (input_active)
@@ -236,7 +237,7 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
         handleReport(buffer_report, kIOHIDReportTypeInput);
         buffer_report->release();
         
-        input_report.FINGERS[0].Priority = 0x0;
+        input_report.FINGERS[0].Priority = 0x5;
         input_report.FINGERS[0].State = 0x0;
         
         buffer_report = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, total_report_len);

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.cpp
@@ -252,6 +252,9 @@ void VoodooI2CMT2SimulatorDevice::constructReportGated(VoodooI2CMultitouchEvent&
     buffer_report = NULL;
 
     if (!input_active) {
+        for (int i = 0; i < 15; i++)
+            new_touch_state[i] = touch_state[i] = 0;
+
         input_report.FINGERS[0].Size = 0x0;
         input_report.FINGERS[0].Pressure = 0x0;
         input_report.FINGERS[0].Touch_Major = 0x0;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -33,7 +33,9 @@ struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT_FINGER {
     UInt8 Touch_Minor;
     UInt8 Size;
     UInt8 Pressure;
-    UInt8 Orientation_Origin;
+    UInt8 Identifier: 4;
+    UInt8 Reserved: 1;
+    UInt8 Angle: 3;
 };
 
 struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT {

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -126,9 +126,7 @@ private:
     VoodooI2CNativeEngine* engine;
     AbsoluteTime start_timestamp;
     OSData* new_get_report_buffer = NULL;
-    UInt16 stashed_unknown[15];
     UInt64 touch_state[15];
-    UInt64 new_touch_state[15];
     int stylus_check = 0;
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -98,8 +98,8 @@ private:
     AbsoluteTime start_timestamp;
     OSData* new_get_report_buffer = NULL;
     UInt16 stashed_unknown[15];
-    UInt8 touch_state[15];
-    UInt8 new_touch_state[15];
+    UInt64 touch_state[15];
+    UInt64 new_touch_state[15];
     int stylus_check = 0;
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -25,10 +25,37 @@
 #define MT2_MAX_X 7612
 #define MT2_MAX_Y 5065
 
+/* Finger Packet
+ +---+---+---+---+---+---+---+---+---+
+ |   | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+ +---+---+---+---+---+---+---+---+---+
+ | 0 |           x: SInt13           |
+ +---+-----------+                   +
+ | 1 |           |                   |
+ +---+           +-------------------+
+ | 2 |           y: SInt13           |
+ +---+-----------+-----------+       +
+ | 3 |   state   |  unknown  |       |
+ |   |   UInt3   |   UInt3   |       |
+ +---+-----------+-----------+-------+
+ | 4 |       touchMajor: UInt8       |
+ +---+-------------------------------+
+ | 5 |       touchMinor: UInt8       |
+ +---+-------------------------------+
+ | 6 |          size: UInt8          |
+ +---+-------------------------------+
+ | 7 |        pressure: UInt8        |
+ +---+-----------+---+---------------+
+ | 8 |   angle   | 0 |   fingerID    |
+ |   |   UInt3   |   |     UInt4     |
+ +---+-----------+---+---------------+
+ */
+
 struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT_FINGER {
-    UInt8 AbsX;
-    UInt8 AbsXY;
-    UInt8 AbsY[2];
+    SInt16 X: 13;
+    SInt16 Y: 13;
+    UInt8 Unknown: 3;
+    UInt8 State: 3;
     UInt8 Touch_Major;
     UInt8 Touch_Minor;
     UInt8 Size;

--- a/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
+++ b/Multitouch Support/Native/VoodooI2CMT2SimulatorDevice.hpp
@@ -22,8 +22,8 @@
 #include "../VoodooI2CDigitiserTransducer.hpp"
 #include "../VoodooI2CMultitouchInterface.hpp"
 
-#define MT2_MAX_X 7612
-#define MT2_MAX_Y 5065
+#define MT2_MAX_X 8134
+#define MT2_MAX_Y 5206
 
 /* Finger Packet
  +---+---+---+---+---+---+---+---+---+
@@ -35,7 +35,7 @@
  +---+           +-------------------+
  | 2 |           y: SInt13           |
  +---+-----------+-----------+       +
- | 3 |   state   |  unknown  |       |
+ | 3 |   state   |  priority |       |
  |   |   UInt3   |   UInt3   |       |
  +---+-----------+-----------+-------+
  | 4 |       touchMajor: UInt8       |
@@ -54,14 +54,14 @@
 struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT_FINGER {
     SInt16 X: 13;
     SInt16 Y: 13;
-    UInt8 Unknown: 3;
+    UInt8 Priority: 3;
     UInt8 State: 3;
     UInt8 Touch_Major;
     UInt8 Touch_Minor;
     UInt8 Size;
     UInt8 Pressure;
     UInt8 Identifier: 4;
-    UInt8 Reserved: 1;
+    UInt8 : 1;
     UInt8 Angle: 3;
 };
 


### PR DESCRIPTION
This PR fixes some multitouch issues in `MT2SimulatorDevice`.

### Fix `touch_state` Overflow

The `touch_state` and `new_touch_state` are defined as UInt8 [0-255], which overflow every 255 touch reports.

https://github.com/alexandred/VoodooI2C/blob/fb787b654e82491bb0bb99272b2991b25831ccc2/Multitouch%20Support/Native/VoodooI2CMT2SimulatorDevice.hpp#L101-L102

https://github.com/alexandred/VoodooI2C/blob/fb787b654e82491bb0bb99272b2991b25831ccc2/Multitouch%20Support/Native/VoodooI2CMT2SimulatorDevice.cpp#L132-L133

https://github.com/alexandred/VoodooI2C/blob/fb787b654e82491bb0bb99272b2991b25831ccc2/Multitouch%20Support/Native/VoodooI2CMT2SimulatorDevice.cpp#L173-L179

This causes a touch reset issue when trying to touch and hold for about two seconds.

**Screen recording**
![flash_bug](https://user-images.githubusercontent.com/10056397/76780041-acd69000-67ac-11ea-96f2-56b9bc786a31.gif)

---

### Amend Definitions of Finger Packet

worked out the remaining unknown bits.

```cpp
/* Finger Packet
 +---+---+---+---+---+---+---+---+---+
 |   | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
 +---+---+---+---+---+---+---+---+---+
 | 0 |           x: SInt13           |
 +---+-----------+                   +
 | 1 |           |                   |
 +---+           +-------------------+
 | 2 |           y: SInt13           |
 +---+-----------+-----------+       +
 | 3 |   state   |  priority |       |
 |   |   UInt3   |   UInt3   |       |
 +---+-----------+-----------+-------+
 | 4 |       touchMajor: UInt8       |
 +---+-------------------------------+
 | 5 |       touchMinor: UInt8       |
 +---+-------------------------------+
 | 6 |          size: UInt8          |
 +---+-------------------------------+
 | 7 |        pressure: UInt8        |
 +---+-----------+---+---------------+
 | 8 |   angle   | 0 |   fingerID    |
 |   |   UInt3   |   |     UInt4     |
 +---+-----------+---+---------------+
 */

struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT_FINGER {
    SInt16 X: 13;
    SInt16 Y: 13;
    UInt8 Priority: 3;
    UInt8 State: 3;
    UInt8 Touch_Major;
    UInt8 Touch_Minor;
    UInt8 Size;
    UInt8 Pressure;
    UInt8 Identifier: 4;
    UInt8 : 1;
    UInt8 Angle: 3;
};
```

Bit-field is utilized for better readability. https://github.com/alexandred/VoodooI2C/commit/ae706983cff293a988d7ca1251e5399b7fb3f97a

The angle value of the finger movement is implemented, https://github.com/alexandred/VoodooI2C/pull/254/commits/e0499d4caa7a4e30c101da3fe9e41e6321814bbe might be helpful for 3F and 4F gestures.

---

### Fix 3-Finger & 4-Finger Touch Occasionally Fall back to 2-F Touch

The value of the last 3 bits of `newunknown >> 2` needs to be greater than 0.

https://github.com/alexandred/VoodooI2C/blob/fb787b654e82491bb0bb99272b2991b25831ccc2/Multitouch%20Support/Native/VoodooI2CMT2SimulatorDevice.cpp#L163-L166

Currently, the three bits would occasionally set to 0 or overflow when 3 or 4 fingers are involved.
This causes 3F and 4F touch to occasionally fall back to 2F touch.

**Screen recording**
![3f_bug](https://user-images.githubusercontent.com/10056397/76845599-68e09b00-683f-11ea-92b9-c9099861495b.gif)
Thanks @kirainmoe for capturing this.

The `newunknown` now is replaced with `state` and `priority`. https://github.com/alexandred/VoodooI2C/commit/69d8faab6a7cf81d4440c54a188fcf0d726e5534

---

### Maintain Touch State based on Finger ID

Finger data in transducer shuffle when a new finger comes in and finger ids are recounted, as a result, the `touch_state` fails to follow the right finger.

This can cause issues like the edge gesture doesn't work when shuffle happens.

**Screen recording**
![edge_bug](https://user-images.githubusercontent.com/10056397/76858155-22973600-6857-11ea-9765-1d9d0b7e0437.gif)
![figure_1](https://user-images.githubusercontent.com/10056397/76856178-072a2c00-6853-11ea-9ece-660e1de12ca4.png)


Therefore, we need to maintain the `touch_state` based on the finger id. https://github.com/alexandred/VoodooI2C/commit/99510967fa824a8c5781684d6deac2ac5aa9cfe6