### PR TITLE
Fix kernel panic after wake, related to the memory mapping:

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
@@ -30,6 +30,7 @@ IOReturn VoodooI2CACPIController::setPowerState(unsigned long whichState, IOServ
 
     if (whichState == kIOPMPowerOff) {
         physical_device.awake = false;
+        unmapMemory();
 
         setACPIPowerState(kVoodooI2CStateOff);
 
@@ -37,7 +38,8 @@ IOReturn VoodooI2CACPIController::setPowerState(unsigned long whichState, IOServ
     } else {
         if (!physical_device.awake) {
             setACPIPowerState(kVoodooI2CStateOn);
-
+            if (mapMemory() != kIOReturnSuccess)
+                IOLog("%s::%s Could not map memory\n", getName(), physical_device.name);
             physical_device.awake = true;
             IOLog("%s::%s Woke up\n", getName(), physical_device.name);
         }

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
@@ -40,7 +40,6 @@ IOReturn VoodooI2CController::mapMemory() {
 
 IOReturn VoodooI2CController::unmapMemory() {
     OSSafeReleaseNULL(physical_device.mmap);
-    physical_device.mmap = 0;
     return kIOReturnSuccess;
 }
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
@@ -38,6 +38,12 @@ IOReturn VoodooI2CController::mapMemory() {
     }
 }
 
+IOReturn VoodooI2CController::unmapMemory() {
+    OSSafeReleaseNULL(physical_device.mmap);
+    physical_device.mmap = 0;
+    return kIOReturnSuccess;
+}
+
 VoodooI2CController* VoodooI2CController::probe(IOService* provider, SInt32* score) {
     if (!super::probe(provider, score)) {
         if (debug_logging)
@@ -76,7 +82,16 @@ exit:
 }
 
 UInt32 VoodooI2CController::readRegister(int offset) {
-    return *(const volatile UInt32 *)(physical_device.mmap->getVirtualAddress() + offset);
+    if (physical_device.mmap != 0) {
+         IOVirtualAddress address = physical_device.mmap->getVirtualAddress();
+         if (address != 0)
+             return *(const volatile UInt32 *)(address + offset);
+         else
+             IOLog("%s::%s readRegister at offset 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
+     } else {
+         IOLog("%s::%s readRegister at offset 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
+     }
+     return 0;
 }
 
 void VoodooI2CController::releaseResources() {
@@ -136,5 +151,13 @@ void VoodooI2CController::stop(IOService* provider) {
 }
 
 void VoodooI2CController::writeRegister(UInt32 value, int offset) {
-    *(volatile UInt32 *)(physical_device.mmap->getVirtualAddress() + offset) = value;
+    if (physical_device.mmap != 0) {
+        IOVirtualAddress address = physical_device.mmap->getVirtualAddress();
+        if (address != 0)
+            *(volatile UInt32 *)(address + offset) = value;
+        else
+            IOLog("%s::%s writeRegister at 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
+    } else {
+        IOLog("%s::%s writeRegister at 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
+    }
 }

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
@@ -103,7 +103,7 @@ class EXPORT VoodooI2CController : public IOService {
      */
 
     IOReturn mapMemory();
-    
+
     /* Releases the controller's mapped memory
       *
       * @return *KIOReturnSuccess* on successful releasing, *kIOReturnDeviceError*
@@ -111,6 +111,7 @@ class EXPORT VoodooI2CController : public IOService {
       */
 
     IOReturn unmapMemory();
+
     /* Publishes a <VoodooI2CControllerNub> entry into the IORegistry for matching
      *
      * This function instantiates a new <VoodooI2CControllerNub> object and attaches it

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
@@ -103,6 +103,14 @@ class EXPORT VoodooI2CController : public IOService {
      */
 
     IOReturn mapMemory();
+    
+    /* Releases the controller's mapped memory
+      *
+      * @return *KIOReturnSuccess* on successful releasing, *kIOReturnDeviceError*
+      *  otherwise
+      */
+
+    IOReturn unmapMemory();
 
     /* Publishes a <VoodooI2CControllerNub> entry into the IORegistry for matching
      *

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
@@ -111,7 +111,7 @@ class EXPORT VoodooI2CController : public IOService {
       */
 
     IOReturn unmapMemory();
-
+    
     /* Publishes a <VoodooI2CControllerNub> entry into the IORegistry for matching
      *
      * This function instantiates a new <VoodooI2CControllerNub> object and attaches it

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
@@ -111,7 +111,6 @@ class EXPORT VoodooI2CController : public IOService {
       */
 
     IOReturn unmapMemory();
-    
     /* Publishes a <VoodooI2CControllerNub> entry into the IORegistry for matching
      *
      * This function instantiates a new <VoodooI2CControllerNub> object and attaches it

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -79,11 +79,13 @@ IOReturn VoodooI2CPCIController::setPowerState(unsigned long whichState, IOServi
 
     if (whichState == kIOPMPowerOff) {
         physical_device.awake = false;
-
+        unmapMemory();
         IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);
     } else {
         if (!physical_device.awake) {
             configurePCI();
+            if (mapMemory() != kIOReturnSuccess)
+                IOLog("%s::%s Could not map memory\n", getName(), physical_device.name);
             skylakeLPSSResetHack();
 
             physical_device.awake = true;


### PR DESCRIPTION
panic(cpu 5 caller 0xffffff80046dda4d): Kernel trap at 0xffffff7f88050d81, type 14=page fault, registers:
CR0: 0x000000008001003b, CR2: 0x0000000000000000, CR3: 0x00000000124c2000, CR4: 0x00000000003626e0
RAX: 0x0000000000000000, RBX: 0x0000000000000204, RCX: 0x0000000000000000, RDX: 0x0000000000000204
RSP: 0xffffff8111c03e00, RBP: 0xffffff8111c03e10, RSI: 0x0000000000000007, RDI: 0x0000000000000000
R8:  0x0000000000100006, R9:  0x0000000000000004, R10: 0x00000000f0000000, R11: 0x0000000000000000
R12: 0xffffff8004e0db80, R13: 0xffffff8021a019f0, R14: 0x0000000000000007, R15: 0xffffff8021a96400
RFL: 0x0000000000010246, RIP: 0xffffff7f88050d81, CS:  0x0000000000000008, SS:  0x0000000000000010
Fault CR2: 0x0000000000000000, Error code: 0x0000000000000000, Fault CPU: 0x5, PL: 0, VF: 1

Backtrace (CPU 5), Frame : Return Address
0xffffff8111c038d0 : 0xffffff80045b058d mach_kernel : _handle_debugger_trap + 0x47d
0xffffff8111c03920 : 0xffffff80046ec0f5 mach_kernel : _kdp_i386_trap + 0x155
0xffffff8111c03960 : 0xffffff80046dd82a mach_kernel : _kernel_trap + 0x50a
0xffffff8111c039d0 : 0xffffff800455d9d0 mach_kernel : _return_from_trap + 0xe0
0xffffff8111c039f0 : 0xffffff80045affa7 mach_kernel : _panic_trap_to_debugger + 0x197
0xffffff8111c03b10 : 0xffffff80045afdf3 mach_kernel : _panic + 0x63
0xffffff8111c03b80 : 0xffffff80046dda4d mach_kernel : _kernel_trap + 0x72d
0xffffff8111c03cf0 : 0xffffff800455d9d0 mach_kernel : _return_from_trap + 0xe0
0xffffff8111c03d10 : 0xffffff7f88050d81 com.alexandred.VoodooI2C : __ZN19VoodooI2CController13writeRegisterEji + 0x13
0xffffff8111c03e10 : 0xffffff7f88055934 com.alexandred.VoodooI2C : __ZN22VoodooI2CPCIController13setPowerStateEmP9IOService + 0x36
0xffffff8111c03e30 : 0xffffff8004c3cd87 mach_kernel : __ZN9IOService19driverSetPowerStateEv + 0x177
0xffffff8111c03ea0 : 0xffffff8004c3cb3a mach_kernel : __ZN9IOService15pmDriverCalloutEPS_ + 0x2a
0xffffff8111c03ec0 : 0xffffff80045ef7a5 mach_kernel : _thread_call_delayed_timer + 0xef5
0xffffff8111c03f40 : 0xffffff80045ef345 mach_kernel : _thread_call_delayed_timer + 0xa95
0xffffff8111c03fa0 : 0xffffff800455d0ce mach_kernel : _call_continuation + 0x2e