### PR TITLE
Optimise Polling Mode

### DIFF
--- a/Dependencies/helpers.hpp
+++ b/Dependencies/helpers.hpp
@@ -35,4 +35,7 @@ static IOPMPowerState VoodooI2CIOPMPowerStates[kVoodooI2CIOPMNumberPowerStates] 
     {1, kIOPMPowerOn, kIOPMPowerOn, kIOPMPowerOn, 0, 0, 0, 0, 0, 0, 0, 0}
 };
 
+// message number used for Polling Mode optimisation
+#define kIOMessageVoodooNativeEngineMessage 54321
+
 #endif /* helpers_hpp */

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -19,6 +19,7 @@
 
 #include "../../Dependencies/VoodooInput/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h"
 #include "../../Dependencies/VoodooInput/VoodooInput/VoodooInputMultitouch/VoodooInputMessages.h"
+#include "../../Dependencies/helpers.hpp"
 
 class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     OSDeclareDefaultStructors(VoodooI2CNativeEngine);
@@ -26,6 +27,7 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     VoodooInputEvent message;
     VoodooI2CMultitouchInterface* parentProvider;
     IOService* voodooInputInstance;
+    IOService* voodooI2CHIDInstance;
  public:
     bool start(IOService* provider) override;
     void stop(IOService* provider) override;


### PR DESCRIPTION
Notify VoodooI2CHIDDevice when touch pad data were handled and sent to VoodooInput.
In VoodooI2CHIDDevice it will be used to adjust polling mode timer interval, it will be dependent on touch pad usage.
Change for VoodooI2CHIDDevice will be committed in a separate pull request.