### PR TITLE
Click button to emulate Force Touch

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -51,6 +51,15 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
 
         inputTransducer->currentCoordinates.pressure = transducer->tip_pressure.value();
         inputTransducer->previousCoordinates.pressure = transducer->tip_pressure.last.value;
+
+        // Force Touch emulation
+        // The button state is saved in the first transducer
+        if (((VoodooI2CDigitiserTransducer*) event.transducers->getObject(0))->physical_button.value()) {
+            inputTransducer->supportsPressure = true;
+            inputTransducer->isPhysicalButtonDown = 0x0;
+            inputTransducer->currentCoordinates.pressure = 0xff;
+            inputTransducer->currentCoordinates.width = 10;
+        }
     }
     
     super::messageClient(kIOMessageVoodooInputMessage, voodooInputInstance, &message, sizeof(VoodooInputEvent));


### PR DESCRIPTION
Regarding #244, this commit uses the button to emulate Force Touch.

Since it is the only feasible way to emulate Force Touch, we don't need to provide the configuration in `info.plist` like VoodooPS2. It can be easily disabled in system trackpad preference, which is more friendly and accessible.