### PR TITLE
Override handleIsOpen for MT engine to fix leak

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -138,11 +138,15 @@ bool VoodooI2CNativeEngine::handleOpen(IOService *forClient, IOOptionBits option
         
         return true;
     }
-    
-    return super::handleOpen(forClient, options, arg);
+    return false;
+}
+
+bool VoodooI2CNativeEngine::handleIsOpen(const IOService *forClient) const {
+    return voodooInputInstance != NULL && forClient == voodooInputInstance;
 }
 
 void VoodooI2CNativeEngine::handleClose(IOService *forClient, IOOptionBits options) {
-    OSSafeReleaseNULL(voodooInputInstance);
-    super::handleClose(forClient, options);
+    if (voodooInputInstance && forClient == voodooInputInstance) {
+        OSSafeReleaseNULL(voodooInputInstance);
+    }
 }

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -36,6 +36,7 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     void stop(IOService* provider) override;
     
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
+    bool handleIsOpen(const IOService *forClient) const override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
     
     MultitouchReturn handleInterruptReport(VoodooI2CMultitouchEvent event, AbsoluteTime timestamp);


### PR DESCRIPTION
Fix VoodooInput instance leaks when unloading VoodooI2CHID. Refer to https://github.com/alexandred/VoodooI2C/issues/291.