### PR TITLE
Optimize I2C controller

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
@@ -8,6 +8,9 @@
 #include "VoodooI2CController.hpp"
 #include "VoodooI2CControllerNub.hpp"
 
+// Log only if current thread is interruptible, otherwise we will get a panic.
+#define TryLog(args...) do { if (ml_get_interrupts_enabled()) IOLog(args); } while (0)
+
 #define super IOService
 OSDefineMetaClassAndStructors(VoodooI2CController, IOService);
 
@@ -86,9 +89,9 @@ UInt32 VoodooI2CController::readRegister(int offset) {
          if (address != 0)
              return *(const volatile UInt32 *)(address + offset);
          else
-             IOLog("%s::%s readRegister at offset 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
+             TryLog("%s::%s readRegister at offset 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
      } else {
-         IOLog("%s::%s readRegister at offset 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
+         TryLog("%s::%s readRegister at offset 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
      }
      return 0;
 }
@@ -155,8 +158,8 @@ void VoodooI2CController::writeRegister(UInt32 value, int offset) {
         if (address != 0)
             *(volatile UInt32 *)(address + offset) = value;
         else
-            IOLog("%s::%s writeRegister at 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
+            TryLog("%s::%s writeRegister at 0x%x failed to get a virtual address\n", getName(), physical_device.name, offset);
     } else {
-        IOLog("%s::%s writeRegister at 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
+        TryLog("%s::%s writeRegister at 0x%x failed since mamory was not mapped\n", getName(), physical_device.name, offset);
     }
 }

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -418,6 +418,7 @@ IOReturn VoodooI2CControllerDriver::setPowerState(unsigned long whichState, IOSe
         bus_device.awake = false;
         toggleBusState(kVoodooI2CStateOff);
         nub->disableInterrupt(0);
+        nub->unregisterInterrupt(0);
         IOLog("%s::%s Going to sleep\n", getName(), bus_device.name);
     } else {
         if (!bus_device.awake) {
@@ -425,7 +426,11 @@ IOReturn VoodooI2CControllerDriver::setPowerState(unsigned long whichState, IOSe
             initialiseBus();
             toggleInterrupts(kVoodooI2CStateOff);
             bus_device.awake = true;
-            nub->enableInterrupt(0);
+            if (nub->registerInterrupt(0, this, OSMemberFunctionCast(IOInterruptAction, this, &VoodooI2CControllerDriver::handleInterrupt), 0) != kIOReturnSuccess) {
+                IOLog("%s::%s::Could not register interrupt\n", getName(), bus_device.name);
+            } else {
+                nub->enableInterrupt(0);
+            }
             IOLog("%s::%s Woke up\n", getName(), bus_device.name);
         }
     }

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -83,7 +83,7 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
 
     /* Handles an interrupt that has been asserted by the controller */
 
-    void handleInterrupt(OSObject* owner, IOInterruptEventSource* src, int intCount);
+    void handleInterrupt(OSObject* target, void* refCon, IOService* nubDevice, int source);
 
     /* Initialises <VoodooI2CControllerDriver> class
      * @properties OSDictionary* representing the matched personality
@@ -146,7 +146,6 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
 
  private:
     IOCommandGate* command_gate;
-    IOInterruptEventSource* interrupt_source;
     IOWorkLoop* work_loop;
 
     /* Requests the nub to fetch bus configuration values from the ACPI tables

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -147,6 +147,7 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
  private:
     IOCommandGate* command_gate;
     IOWorkLoop* work_loop;
+    IOLock* i2c_bus_lock;
 
     /* Requests the nub to fetch bus configuration values from the ACPI tables
      *

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -147,7 +147,7 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
  private:
     IOCommandGate* command_gate;
     IOWorkLoop* work_loop;
-    IOLock* i2c_bus_lock;
+    IOLock* i2c_bus_lock = nullptr;
 
     /* Requests the nub to fetch bus configuration values from the ACPI tables
      *


### PR DESCRIPTION
- Use direct interrupt for reading in I2C bus. Improve performance and reduce CPU load. https://github.com/alexandred/VoodooI2C/issues/259#issuecomment-613545186
- Lock the I2C session to avoid R/W re-entrancy of I2C bus. (Partially) fix https://github.com/alexandred/VoodooI2C/issues/284 and https://github.com/alexandred/VoodooI2C/issues/281.
- Wait and disable I2C interrupt when entering the sleep state, to avoid potential interrupts after `setPowerState()`.
- In `readRegister()` and `writeRegister()`, log only if the current thread is interruptible to avoid panic. Fix https://github.com/alexandred/VoodooI2C/issues/284#issuecomment-616837648.