### PR TITLE
Correct issue with touchscreens requiring an additional finger for mu…

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -95,6 +95,8 @@ bool VoodooI2CNativeEngine::start(IOService* provider) {
     
     setProperty(kIOFBTransformKey, 0ull, 32);
     setProperty("VoodooInputSupported", kOSBooleanTrue);
+    
+    stylus_check = 0;
 
     return true;
 }

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -20,8 +20,16 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
     message.contact_count = event.contact_count;
     memset(message.transducers, 0, VOODOO_INPUT_MAX_TRANSDUCERS * sizeof(VoodooInputTransducer));
     
+    VoodooI2CDigitiserTransducer* transducer = (VoodooI2CDigitiserTransducer*) event.transducers->getObject(0);
+
+    if (!transducer)
+        return MultitouchReturnBreak;
+    
+    if (transducer->type == kDigitiserTransducerStylus)
+        stylus_check = 1;
+    
     for (int i = 0; i < event.contact_count; i++) {
-        VoodooI2CDigitiserTransducer* transducer = (VoodooI2CDigitiserTransducer*) event.transducers->getObject(i);
+        VoodooI2CDigitiserTransducer* transducer = (VoodooI2CDigitiserTransducer*) event.transducers->getObject(i+stylus_check);
         VoodooInputTransducer* inputTransducer = &message.transducers[i];
         
         if (!transducer) {

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -40,6 +40,8 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     void handleClose(IOService *forClient, IOOptionBits options) override;
     
     MultitouchReturn handleInterruptReport(VoodooI2CMultitouchEvent event, AbsoluteTime timestamp);
+ private:
+    int stylus_check = 0;
 };
 
 


### PR DESCRIPTION
…ltitouch gestures.  This was due to the device presenting a stylus at transducer 0.  A simple check prior to sending the message to VoodooInput eliminates the problem.  The stylus check in VoodooInput should be removed as unnecessary.