### PR TITLE
Track interrupt state in I2C controller

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -70,6 +70,7 @@ void VoodooI2CControllerDriver::handleAbortI2C() {
 }
 
 void VoodooI2CControllerDriver::handleInterrupt(OSObject* target, void* refCon, IOService* nubDevice, int source) {
+    /* Direct interrupt context. Do NOT block the thread by memory allocation, IOLog, IOLockLock, command_gate->runAction, ... */
     nub->disableInterrupt(0);
 
     UInt32 status, enabled;

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -148,6 +148,7 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
     IOCommandGate* command_gate;
     IOWorkLoop* work_loop;
     IOLock* i2c_bus_lock = nullptr;
+    bool is_interrupt_registered = false;
 
     /* Requests the nub to fetch bus configuration values from the ACPI tables
      *

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -288,6 +288,22 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
      */
 
     IOReturn waitBusNotBusyI2C();
+
+    /* Register and enable the interrupt for I2C bus
+     *
+     * Note: Do NOT call this function in direct interrupt context.
+     *
+     * @return *kIOReturnSuccess* on interrupt successfully registered and enabled, *kIOReturnStillOpen* if already started.
+     * Otherwise *kIOReturnNoInterrupt* is returned if the source is not valid; *kIOReturnNoResources* is returned if the interrupt already has an installed handler.
+     */
+    IOReturn startI2CInterrupt();
+
+    /* Disable and unregister the interrupt for I2C bus
+     *
+     * Note: Do NOT call this function in direct interrupt context.
+     *
+     */
+    void stopI2CInterrupt();
 };
 
 


### PR DESCRIPTION
Track the interrupt state in the I2C controller to avoid the interrupt being disabled and unregistered twice when unloading.

I notice when kextunloading VoodooI2CHID, the `VoodooI2CControllerDriver::setPowerState` gets called and disables the interrupt. So the interrupt will be disabled and unregistered for the second time in `stop()` when unloading VoodooI2C, which somehow will cause a deadlock in the kernel.