### PR TITLE
Github Actions CI workflow

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and analyse default scheme using xcodebuild command
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Checkout

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -19,7 +19,6 @@ jobs:
         run: git clone https://github.com/acidanthera/MacKernelSDK
         
       - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
-      - run: pip3 install -U pyparsing
       - run: pip3 install cpplint
       - run: pip3 install git+https://github.com/newperson1746/cldoc-fix.git
       - run: git submodule init && git submodule update

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -21,7 +21,7 @@ jobs:
       - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
       - run: pip3 install -U pyparsing
       - run: pip3 install cpplint
-      - run: pip3 install git+https://github.com/VoodooI2C/cldoc.git
+      - run: pip3 install git+https://github.com/newperson1746/cldoc-fix.git
       - run: git submodule init && git submodule update
       
       - name: xcodebuild

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -1,0 +1,33 @@
+name: Xcode - Build and Analyze
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    name: Build and analyse default scheme using xcodebuild command
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: download mackernelsdk
+        run: git clone https://github.com/acidanthera/MacKernelSDK
+        
+      - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
+      - run: pip3 install cpplint
+      - run: pip3 install git+https://github.com/VoodooI2C/cldoc.git
+      - run: git submodule init && git submodule update
+      
+      - name: xcodebuild
+        run: xcodebuild -workspace "VoodooI2C.xcworkspace" -scheme "VoodooI2C" -derivedDataPath build clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+      - name: Upload to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Artifacts
+          path: build/Build/Products/Release

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and analyse default scheme using xcodebuild command
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
         run: git clone https://github.com/acidanthera/MacKernelSDK
         
       - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
-      - run: pip3 install -U setuptools
+      - run: pip3 install -U pyparsing
       - run: pip3 install cpplint
       - run: pip3 install git+https://github.com/VoodooI2C/cldoc.git
       - run: git submodule init && git submodule update

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -19,6 +19,7 @@ jobs:
         run: git clone https://github.com/acidanthera/MacKernelSDK
         
       - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
+      - run: pip3 install -U setuptools
       - run: pip3 install cpplint
       - run: pip3 install git+https://github.com/VoodooI2C/cldoc.git
       - run: git submodule init && git submodule update


### PR DESCRIPTION
Hi,
I forked this repo to compile the most up-to-date version automatically. On each commit will re-compile into Artifacts. I thought this might be useful to upstream to provide nightly builds or something.

Currently this workflow's successful execution is dependent on my forked cldoc, however the changes are minimal (update pyparsing to latest for macOS 12 runner with python3.11, and one line change to one file) and I can open a PR on VoodooI2C/cldoc to upstream that as well. (https://github.com/VoodooI2C/cldoc/pull/2)

Let me know if you have any questions