### PR TITLE
Move AMD quirk handling into VoodooI2CControllerDrivers

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
@@ -53,13 +53,6 @@ bool VoodooI2CACPIController::start(IOService* provider) {
     }
 
     physical_device.acpi_device = OSDynamicCast(IOACPIPlatformDevice, provider);
-
-    OSBoolean *access_intr_mask_workaround  = OSDynamicCast(OSBoolean, this->getProperty("AccessIntrMaskWorkaround"));
-    if (access_intr_mask_workaround) {
-        physical_device.access_intr_mask_workaround = access_intr_mask_workaround->getValue();
-        IOLog("%s::%s AccessIntrMaskWorkaround: %d\n", getName(), physical_device.name, physical_device.access_intr_mask_workaround);
-    }
-
     setACPIPowerState(kVoodooI2CStateOn);
 
     if (mapMemory() != kIOReturnSuccess) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.hpp
@@ -19,15 +19,14 @@
 #define kACPIDevicePathKey "acpi-path"
 #endif
 
-typedef struct {
+struct VoodooI2CControllerPhysicalDevice {
     IOACPIPlatformDevice* acpi_device;
     bool awake = true;
     const char* name;
     IOPCIDevice* pci_device;
     IOMemoryMap* mmap;
     IOService* provider;
-    bool access_intr_mask_workaround = false;
-} VoodooI2CControllerPhysicalDevice;
+};
 
 class VoodooI2CControllerNub;
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerConstants.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerConstants.hpp
@@ -34,6 +34,8 @@
 #define kI2CPropFsHCntKey               "I2CFsHighCount"
 #define kI2CPropFsLCntKey               "I2CFsLowCount"
 
+#define kI2CPropMaskQuirk               "AccessIntrMaskWorkaround"
+
 #define LPSS_PRIVATE_CLOCK_GATING       0x800
 
 #define DW_IC_CON_MASTER                0x1

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerConstants.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerConstants.hpp
@@ -34,7 +34,7 @@
 #define kI2CPropFsHCntKey               "I2CFsHighCount"
 #define kI2CPropFsLCntKey               "I2CFsLowCount"
 
-#define kI2CPropMaskQuirk               "AccessIntrMaskWorkaround"
+#define kI2CPropMaskQuirkKey            "AccessIntrMaskWorkaround"
 
 #define LPSS_PRIVATE_CLOCK_GATING       0x800
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -130,7 +130,7 @@ IOReturn VoodooI2CControllerDriver::getBusConfig() {
     bus_device.acpi_config.ss_lcnt = getNumProperty(kI2CPropSsLCntKey);
     bus_device.acpi_config.fs_hcnt = getNumProperty(kI2CPropFsHCntKey);
     bus_device.acpi_config.fs_lcnt = getNumProperty(kI2CPropFsLCntKey);
-    bus_device.access_intr_mask_workaround = getBoolProperty(kI2CPropMaskQuirk);
+    bus_device.access_intr_mask_workaround = getBoolProperty(kI2CPropMaskQuirkKey);
 
     sdaFallNs = getNumProperty(kI2CPropSdaFallNsKey) ?: 300;  // 0.3us default
     sclFallNs = getNumProperty(kI2CPropSclFallNsKey) ?: 300;  // 0.3us default

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -97,6 +97,16 @@ UInt32 VoodooI2CControllerDriver::getNumProperty(const char *key) {
     return prop->unsigned32BitValue();
 }
 
+bool VoodooI2CControllerDriver::getBoolProperty(const char *key) {
+    OSBoolean *prop = OSDynamicCast(OSBoolean, getProperty(key, gIOServicePlane));
+    if (!prop) {
+        IOLog("%s::%s Failed to get property %s\n", getName(), bus_device.name, key);
+        return false;
+    }
+
+    return prop->getValue();
+}
+
 IOReturn VoodooI2CControllerDriver::getBusConfig() {
     UInt32 sdaFallNs, sclFallNs;
 
@@ -120,6 +130,7 @@ IOReturn VoodooI2CControllerDriver::getBusConfig() {
     bus_device.acpi_config.ss_lcnt = getNumProperty(kI2CPropSsLCntKey);
     bus_device.acpi_config.fs_hcnt = getNumProperty(kI2CPropFsHCntKey);
     bus_device.acpi_config.fs_lcnt = getNumProperty(kI2CPropFsLCntKey);
+    bus_device.access_intr_mask_workaround = getBoolProperty(kI2CPropMaskQuirk);
 
     sdaFallNs = getNumProperty(kI2CPropSdaFallNsKey) ?: 300;  // 0.3us default
     sclFallNs = getNumProperty(kI2CPropSclFallNsKey) ?: 300;  // 0.3us default
@@ -255,7 +266,7 @@ void VoodooI2CControllerDriver::handleInterrupt(OSObject* target, void* refCon, 
 wakeup:
     if (((status & (DW_IC_INTR_TX_ABRT | DW_IC_INTR_STOP_DET)) || bus_device.message_error) && (bus_device.receive_outstanding == 0)) {
         command_gate->commandWakeup(&bus_device.command_complete);
-    } else if (nub->controller->physical_device.access_intr_mask_workaround) {
+    } else if (bus_device.access_intr_mask_workaround) {
         /* Workaround to trigger pending interrupt */
         status = readRegister(DW_IC_INTR_MASK);
         writeRegister(0, DW_IC_INTR_MASK);
@@ -512,7 +523,7 @@ void VoodooI2CControllerDriver::requestTransferI2C() {
     VoodooI2CControllerBusMessage *messages = bus_device.messages;
     UInt32 i2c_configuration, i2c_target = 0, orig;
 
-    if (nub->controller->physical_device.access_intr_mask_workaround) {
+    if (bus_device.access_intr_mask_workaround) {
         // Linux code works with black magic, on macOS with AMD I2C turning off the adapter
         // and rewriting the bus settings is required
         initialiseBus();

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -56,6 +56,7 @@ typedef struct {
     UInt32 transaction_buffer_length;
     UInt8* transaction_buffer;
     UInt32 transaction_fifo_depth;
+    bool access_intr_mask_workaround;
 } VoodooI2CControllerBusDevice;
 
 class VoodooI2CController;
@@ -157,6 +158,14 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
      * @return Property value on success, 0 on failure.
      */
     UInt32 getNumProperty(const char *key);
+
+    /* Request a boolean property from this service or any parent in the
+     * IOService tree.
+     * @key Property name to lookup in IOService tree.
+     *
+     * @return Property value on success, false on failure.
+     */
+    bool getBoolProperty(const char *key);
 
     /* Calculates bus timings using ACPI and Controller properties.
      *


### PR DESCRIPTION
Mostly in preparation for fixing the LPSS gating.
Still unsure how I want to handle clock gating but surely making the ACPI class simpler will help. Makes the AMD quirk similar to how defaults are handled now for bus config too.